### PR TITLE
Secure list and item endpoints with JWT verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+backend/node_modules/
+backend/dist/
+backend/.env
+backend/.env.*

--- a/backend/src/modules/items/routes.test.ts
+++ b/backend/src/modules/items/routes.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import Fastify from 'fastify';
+import jwt from '@fastify/jwt';
+
+import { itemRoutes } from './routes.js';
+
+const JWT_SECRET = 'test-secret';
+
+test('GET /lists/:listId/items rejects missing token', async () => {
+  const app = Fastify();
+  await app.register(jwt, { secret: JWT_SECRET });
+  await app.register(itemRoutes);
+  await app.ready();
+
+  try {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/lists/list_1/items'
+    });
+
+    assert.equal(response.statusCode, 401);
+  } finally {
+    await app.close();
+  }
+});
+
+test('GET /lists/:listId/items returns payload for authenticated user', async () => {
+  const app = Fastify();
+  await app.register(jwt, { secret: JWT_SECRET });
+  await app.register(itemRoutes);
+  await app.ready();
+
+  const token = await app.jwt.sign({
+    sub: 'user_1',
+    email: 'test@example.com'
+  });
+
+  try {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/lists/list_1/items',
+      headers: {
+        authorization: `Bearer ${token}`
+      }
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.json(), { items: [] });
+  } finally {
+    await app.close();
+  }
+});

--- a/backend/src/modules/items/routes.ts
+++ b/backend/src/modules/items/routes.ts
@@ -1,7 +1,11 @@
 import type { FastifyPluginAsync } from 'fastify';
 
 export const itemRoutes: FastifyPluginAsync = async (app) => {
-  app.get('/lists/:listId/items', async () => {
+  app.get('/lists/:listId/items', {
+    preHandler: async (request) => {
+      await request.jwtVerify();
+    }
+  }, async () => {
     return {
       items: []
     };

--- a/backend/src/modules/lists/routes.test.ts
+++ b/backend/src/modules/lists/routes.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import Fastify from 'fastify';
+import jwt from '@fastify/jwt';
+
+import { listRoutes } from './routes.js';
+
+const JWT_SECRET = 'test-secret';
+
+test('GET /lists rejects missing token', async () => {
+  const app = Fastify();
+  await app.register(jwt, { secret: JWT_SECRET });
+  await app.register(listRoutes);
+  await app.ready();
+
+  try {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/lists'
+    });
+
+    assert.equal(response.statusCode, 401);
+  } finally {
+    await app.close();
+  }
+});
+
+test('GET /lists returns payload for authenticated user', async () => {
+  const app = Fastify();
+  await app.register(jwt, { secret: JWT_SECRET });
+  await app.register(listRoutes);
+  await app.ready();
+
+  const token = await app.jwt.sign({
+    sub: 'user_1',
+    email: 'test@example.com'
+  });
+
+  try {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/lists',
+      headers: {
+        authorization: `Bearer ${token}`
+      }
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.json(), { items: [] });
+  } finally {
+    await app.close();
+  }
+});

--- a/backend/src/modules/lists/routes.ts
+++ b/backend/src/modules/lists/routes.ts
@@ -1,7 +1,11 @@
 import type { FastifyPluginAsync } from 'fastify';
 
 export const listRoutes: FastifyPluginAsync = async (app) => {
-  app.get('/lists', async () => {
+  app.get('/lists', {
+    preHandler: async (request) => {
+      await request.jwtVerify();
+    }
+  }, async () => {
     return {
       items: []
     };


### PR DESCRIPTION
### Motivation
- Enforce authentication on list and item read endpoints to meet the project security requirement that every list and item operation requires authorization.
- Prevent anonymous access to `/lists` and `/lists/:listId/items` which were previously public.

### Description
- Add a route-level `preHandler` calling `request.jwtVerify()` to `GET /lists` in `backend/src/modules/lists/routes.ts` to require a valid JWT.
- Add a route-level `preHandler` calling `request.jwtVerify()` to `GET /lists/:listId/items` in `backend/src/modules/items/routes.ts` to require a valid JWT.
- Add route tests `backend/src/modules/lists/routes.test.ts` and `backend/src/modules/items/routes.test.ts` that assert missing tokens return `401` and valid tokens return `200` with the expected payload.
- Add a project `.gitignore` to avoid committing `backend/node_modules/`, `backend/dist/`, and local env files like `backend/.env` and `backend/.env.*`.

### Testing
- Ran `cd backend && npm test` and all tests passed (10/10 tests succeeded). 
- Ran `cd backend && npm run build` and the TypeScript build completed successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cad1501dd88324a7ca6d04a9cc719f)