### PR TITLE
[codex] implement item flow

### DIFF
--- a/backend/src/modules/auth/routes.ts
+++ b/backend/src/modules/auth/routes.ts
@@ -1,17 +1,10 @@
 import argon2 from 'argon2';
-import type { PrismaClient, User } from '@prisma/client';
+import type { PrismaClient } from '@prisma/client';
 import type { FastifyPluginAsync } from 'fastify';
 import { z } from 'zod';
 
+import { prisma } from '../../lib/prisma.js';
 import { toUserResponse } from './utils.js';
-
-type UserResponse = {
-  id: string;
-  email: string;
-  displayName: string;
-  createdAt: Date;
-  updatedAt: Date;
-};
 
 type AuthRoutesDeps = {
   prisma: Pick<PrismaClient, 'user'>;
@@ -43,16 +36,6 @@ const defaultDeps: AuthRoutesDeps = {
     }),
   verifyPassword: async (hash, password) => argon2.verify(hash, password)
 };
-
-function toUserResponse(user: Pick<User, 'id' | 'email' | 'displayName' | 'createdAt' | 'updatedAt'>): UserResponse {
-  return {
-    id: user.id,
-    email: user.email,
-    displayName: user.displayName,
-    createdAt: user.createdAt,
-    updatedAt: user.updatedAt
-  };
-}
 
 function parseBody<T>(schema: z.ZodType<T>, body: unknown) {
   const result = schema.safeParse(body);

--- a/backend/src/modules/items/routes.test.ts
+++ b/backend/src/modules/items/routes.test.ts
@@ -1,0 +1,592 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type { PrismaClient } from '@prisma/client';
+import Fastify from 'fastify';
+import jwt from '@fastify/jwt';
+import sensible from '@fastify/sensible';
+
+import { createItemRoutes } from './routes.js';
+
+const JWT_SECRET = 'test-secret';
+
+type TestUser = {
+  id: string;
+  email: string;
+  displayName: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type TestList = {
+  id: string;
+  name: string;
+  ownerUserId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  memberIds: Set<string>;
+};
+
+type TestItem = {
+  id: string;
+  listId: string;
+  name: string;
+  quantity: string | null;
+  unit: string | null;
+  isChecked: boolean;
+  sortOrder: number;
+  createdByUserId: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+function buildUser(overrides: Partial<TestUser> = {}): TestUser {
+  return {
+    id: 'user_1',
+    email: 'test@example.com',
+    displayName: 'Test User',
+    createdAt: new Date('2026-03-29T10:00:00.000Z'),
+    updatedAt: new Date('2026-03-29T10:00:00.000Z'),
+    ...overrides
+  };
+}
+
+function buildList(overrides: Partial<TestList> = {}): TestList {
+  return {
+    id: 'list_1',
+    name: 'Weekly groceries',
+    ownerUserId: 'user_1',
+    createdAt: new Date('2026-03-29T10:00:00.000Z'),
+    updatedAt: new Date('2026-03-29T10:00:00.000Z'),
+    memberIds: new Set(['user_1']),
+    ...overrides
+  };
+}
+
+function buildItem(overrides: Partial<TestItem> = {}): TestItem {
+  return {
+    id: 'item_1',
+    listId: 'list_1',
+    name: 'Milk',
+    quantity: '2',
+    unit: 'l',
+    isChecked: false,
+    sortOrder: 0,
+    createdByUserId: 'user_1',
+    createdAt: new Date('2026-03-29T10:00:00.000Z'),
+    updatedAt: new Date('2026-03-29T10:00:00.000Z'),
+    ...overrides
+  };
+}
+
+async function buildApp(
+  userById: Map<string, TestUser | undefined>,
+  listsById: Map<string, TestList | undefined>,
+  itemsById: Map<string, TestItem | undefined>
+) {
+  const app = Fastify();
+
+  const prismaMock = {
+    user: {
+      findUnique: async ({ where }: { where: { id?: string; email?: string } }) => {
+        if (where.id) {
+          return userById.get(where.id) ?? null;
+        }
+
+        if (where.email) {
+          return [...userById.values()].find((user) => user?.email === where.email) ?? null;
+        }
+
+        return null;
+      }
+    },
+    shoppingList: {
+      findFirst: async ({
+        where
+      }: {
+        where: {
+          id?: string;
+          members?: {
+            some?: {
+              userId?: string;
+            };
+          };
+        };
+      }) => {
+        const list = where.id ? listsById.get(where.id) ?? null : null;
+
+        if (!list) {
+          return null;
+        }
+
+        const userId = where.members?.some?.userId;
+
+        if (userId && !list.memberIds.has(userId)) {
+          return null;
+        }
+
+        return list;
+      }
+    },
+    listItem: {
+      findMany: async ({
+        where,
+        orderBy,
+        take
+      }: {
+        where?: { listId?: string };
+        orderBy?: { sortOrder?: 'asc' | 'desc' };
+        take?: number;
+      }) => {
+        const listId = where?.listId;
+        let items = [...itemsById.values()].filter((item): item is TestItem => {
+          if (!item) {
+            return false;
+          }
+
+          return listId ? item.listId === listId : true;
+        });
+
+        if (orderBy?.sortOrder === 'asc') {
+          items = items.sort((left, right) => left.sortOrder - right.sortOrder);
+        } else if (orderBy?.sortOrder === 'desc') {
+          items = items.sort((left, right) => right.sortOrder - left.sortOrder);
+        }
+
+        if (take) {
+          items = items.slice(0, take);
+        }
+
+        return items;
+      },
+      findFirst: async ({
+        where
+      }: {
+        where: {
+          id?: string;
+          listId?: string;
+        };
+      }) => {
+        const item = where.id ? itemsById.get(where.id) ?? null : null;
+
+        if (!item) {
+          return null;
+        }
+
+        if (where.listId && item.listId !== where.listId) {
+          return null;
+        }
+
+        return item;
+      },
+      create: async ({
+        data
+      }: {
+        data: {
+          listId: string;
+          name: string;
+          quantity?: string | null;
+          unit?: string | null;
+          isChecked: boolean;
+          sortOrder: number;
+          createdByUserId: string;
+        };
+      }) => {
+        const now = new Date('2026-03-30T10:00:00.000Z');
+        const item = buildItem({
+          id: `item_${itemsById.size + 1}`,
+          listId: data.listId,
+          name: data.name,
+          quantity: data.quantity ?? null,
+          unit: data.unit ?? null,
+          isChecked: data.isChecked,
+          sortOrder: data.sortOrder,
+          createdByUserId: data.createdByUserId,
+          createdAt: now,
+          updatedAt: now
+        });
+
+        itemsById.set(item.id, item);
+        return item;
+      },
+      update: async ({
+        where,
+        data
+      }: {
+        where: {
+          id: string;
+        };
+        data: {
+          name?: string;
+          quantity?: string | null;
+          unit?: string | null;
+          isChecked?: boolean;
+        };
+      }) => {
+        const item = itemsById.get(where.id);
+
+        if (!item) {
+          throw new Error('Item not found');
+        }
+
+        const updatedItem = {
+          ...item,
+          name: data.name ?? item.name,
+          quantity: data.quantity === undefined ? item.quantity : data.quantity,
+          unit: data.unit === undefined ? item.unit : data.unit,
+          isChecked: data.isChecked ?? item.isChecked,
+          updatedAt: new Date('2026-03-30T10:00:00.000Z')
+        };
+
+        itemsById.set(where.id, updatedItem);
+        return updatedItem;
+      },
+      delete: async ({ where }: { where: { id: string } }) => {
+        const item = itemsById.get(where.id);
+
+        if (!item) {
+          throw new Error('Item not found');
+        }
+
+        itemsById.delete(where.id);
+        return item;
+      }
+    }
+  } as unknown as Pick<PrismaClient, 'user' | 'shoppingList' | 'listItem'>;
+
+  await app.register(sensible);
+  await app.register(jwt, {
+    secret: JWT_SECRET
+  });
+  await app.register(
+    createItemRoutes({
+      prisma: prismaMock
+    })
+  );
+
+  await app.ready();
+  return app;
+}
+
+test('GET /lists/:listId/items returns items visible to the user ordered by sortOrder', async () => {
+  const user = buildUser();
+  const list = buildList({
+    memberIds: new Set([user.id])
+  });
+  const items = new Map<string, TestItem | undefined>([
+    [
+      'item_1',
+      buildItem({
+        id: 'item_1',
+        listId: list.id,
+        name: 'Bread',
+        sortOrder: 2,
+        createdByUserId: user.id
+      })
+    ],
+    [
+      'item_2',
+      buildItem({
+        id: 'item_2',
+        listId: list.id,
+        name: 'Butter',
+        sortOrder: 1,
+        createdByUserId: user.id
+      })
+    ]
+  ]);
+  const app = await buildApp(new Map([[user.id, user]]), new Map([[list.id, list]]), items);
+  const token = await app.jwt.sign({
+    sub: user.id,
+    email: user.email
+  });
+
+  try {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/lists/${list.id}/items`,
+      headers: {
+        authorization: `Bearer ${token}`
+      }
+    });
+
+    assert.equal(response.statusCode, 200);
+
+    const body = response.json() as {
+      items: Array<{ id: string; name: string; sortOrder: number }>;
+    };
+
+    assert.deepEqual(
+      body.items.map((item) => item.name),
+      ['Butter', 'Bread']
+    );
+    assert.deepEqual(
+      body.items.map((item) => item.sortOrder),
+      [1, 2]
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test('GET /lists/:listId/items returns 404 for a list the user cannot access', async () => {
+  const user = buildUser();
+  const list = buildList({
+    ownerUserId: 'user_2',
+    memberIds: new Set(['user_2'])
+  });
+  const app = await buildApp(new Map([[user.id, user]]), new Map([[list.id, list]]), new Map());
+  const token = await app.jwt.sign({
+    sub: user.id,
+    email: user.email
+  });
+
+  try {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/lists/${list.id}/items`,
+      headers: {
+        authorization: `Bearer ${token}`
+      }
+    });
+
+    assert.equal(response.statusCode, 404);
+  } finally {
+    await app.close();
+  }
+});
+
+test('POST /lists/:listId/items creates a new item for a visible list', async () => {
+  const user = buildUser();
+  const list = buildList({
+    memberIds: new Set([user.id])
+  });
+  const items = new Map<string, TestItem | undefined>([
+    [
+      'item_1',
+      buildItem({
+        id: 'item_1',
+        listId: list.id,
+        sortOrder: 0,
+        createdByUserId: user.id
+      })
+    ]
+  ]);
+  const app = await buildApp(new Map([[user.id, user]]), new Map([[list.id, list]]), items);
+  const token = await app.jwt.sign({
+    sub: user.id,
+    email: user.email
+  });
+
+  try {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/lists/${list.id}/items`,
+      headers: {
+        authorization: `Bearer ${token}`
+      },
+      payload: {
+        name: '  Apples  ',
+        quantity: ' 2 ',
+        unit: ' kg '
+      }
+    });
+
+    assert.equal(response.statusCode, 201);
+
+    const body = response.json() as {
+      item: {
+        name: string;
+        quantity: string | null;
+        unit: string | null;
+        isChecked: boolean;
+        sortOrder: number;
+        createdByUserId: string;
+      };
+    };
+
+    assert.equal(body.item.name, 'Apples');
+    assert.equal(body.item.quantity, '2');
+    assert.equal(body.item.unit, 'kg');
+    assert.equal(body.item.isChecked, false);
+    assert.equal(body.item.sortOrder, 1);
+    assert.equal(body.item.createdByUserId, user.id);
+    assert.equal(items.size, 2);
+  } finally {
+    await app.close();
+  }
+});
+
+test('POST /lists/:listId/items rejects invalid payload', async () => {
+  const user = buildUser();
+  const list = buildList({
+    memberIds: new Set([user.id])
+  });
+  const app = await buildApp(new Map([[user.id, user]]), new Map([[list.id, list]]), new Map());
+  const token = await app.jwt.sign({
+    sub: user.id,
+    email: user.email
+  });
+
+  try {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/lists/${list.id}/items`,
+      headers: {
+        authorization: `Bearer ${token}`
+      },
+      payload: {
+        name: ' '
+      }
+    });
+
+    assert.equal(response.statusCode, 400);
+  } finally {
+    await app.close();
+  }
+});
+
+test('PATCH /lists/:listId/items/:itemId updates an item', async () => {
+  const user = buildUser();
+  const list = buildList({
+    memberIds: new Set([user.id])
+  });
+  const item = buildItem({
+    id: 'item_1',
+    listId: list.id,
+    name: 'Milk',
+    quantity: '1',
+    unit: 'l',
+    isChecked: false,
+    createdByUserId: user.id
+  });
+  const items = new Map<string, TestItem | undefined>([[item.id, item]]);
+  const app = await buildApp(new Map([[user.id, user]]), new Map([[list.id, list]]), items);
+  const token = await app.jwt.sign({
+    sub: user.id,
+    email: user.email
+  });
+
+  try {
+    const response = await app.inject({
+      method: 'PATCH',
+      url: `/lists/${list.id}/items/${item.id}`,
+      headers: {
+        authorization: `Bearer ${token}`
+      },
+      payload: {
+        name: 'Oat milk',
+        isChecked: true
+      }
+    });
+
+    assert.equal(response.statusCode, 200);
+
+    const body = response.json() as {
+      item: {
+        name: string;
+        quantity: string | null;
+        unit: string | null;
+        isChecked: boolean;
+      };
+    };
+
+    assert.equal(body.item.name, 'Oat milk');
+    assert.equal(body.item.quantity, '1');
+    assert.equal(body.item.unit, 'l');
+    assert.equal(body.item.isChecked, true);
+  } finally {
+    await app.close();
+  }
+});
+
+test('PATCH /lists/:listId/items/:itemId rejects empty payload', async () => {
+  const user = buildUser();
+  const list = buildList({
+    memberIds: new Set([user.id])
+  });
+  const item = buildItem({
+    id: 'item_1',
+    listId: list.id,
+    createdByUserId: user.id
+  });
+  const app = await buildApp(new Map([[user.id, user]]), new Map([[list.id, list]]), new Map([[item.id, item]]));
+  const token = await app.jwt.sign({
+    sub: user.id,
+    email: user.email
+  });
+
+  try {
+    const response = await app.inject({
+      method: 'PATCH',
+      url: `/lists/${list.id}/items/${item.id}`,
+      headers: {
+        authorization: `Bearer ${token}`
+      },
+      payload: {}
+    });
+
+    assert.equal(response.statusCode, 400);
+  } finally {
+    await app.close();
+  }
+});
+
+test('DELETE /lists/:listId/items/:itemId removes the item', async () => {
+  const user = buildUser();
+  const list = buildList({
+    memberIds: new Set([user.id])
+  });
+  const item = buildItem({
+    id: 'item_1',
+    listId: list.id,
+    createdByUserId: user.id
+  });
+  const items = new Map<string, TestItem | undefined>([[item.id, item]]);
+  const app = await buildApp(new Map([[user.id, user]]), new Map([[list.id, list]]), items);
+  const token = await app.jwt.sign({
+    sub: user.id,
+    email: user.email
+  });
+
+  try {
+    const response = await app.inject({
+      method: 'DELETE',
+      url: `/lists/${list.id}/items/${item.id}`,
+      headers: {
+        authorization: `Bearer ${token}`
+      }
+    });
+
+    assert.equal(response.statusCode, 204);
+    assert.equal(items.size, 0);
+  } finally {
+    await app.close();
+  }
+});
+
+test('DELETE /lists/:listId/items/:itemId returns 404 for a missing item', async () => {
+  const user = buildUser();
+  const list = buildList({
+    memberIds: new Set([user.id])
+  });
+  const app = await buildApp(new Map([[user.id, user]]), new Map([[list.id, list]]), new Map());
+  const token = await app.jwt.sign({
+    sub: user.id,
+    email: user.email
+  });
+
+  try {
+    const response = await app.inject({
+      method: 'DELETE',
+      url: `/lists/${list.id}/items/missing-item`,
+      headers: {
+        authorization: `Bearer ${token}`
+      }
+    });
+
+    assert.equal(response.statusCode, 404);
+  } finally {
+    await app.close();
+  }
+});

--- a/backend/src/modules/items/routes.ts
+++ b/backend/src/modules/items/routes.ts
@@ -1,9 +1,311 @@
-import type { FastifyPluginAsync } from 'fastify';
+import type { ListItem, PrismaClient, ShoppingList, User } from '@prisma/client';
+import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
 
-export const itemRoutes: FastifyPluginAsync = async (app) => {
-  app.get('/lists/:listId/items', async () => {
-    return {
-      items: []
-    };
-  });
+import { prisma } from '../../lib/prisma.js';
+
+type JwtUserPayload = {
+  sub: string;
+  email: string;
 };
+
+type ItemResponse = {
+  id: string;
+  listId: string;
+  name: string;
+  quantity: string | null;
+  unit: string | null;
+  isChecked: boolean;
+  sortOrder: number;
+  createdByUserId: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type ItemRepository = Pick<PrismaClient['listItem'], 'findMany' | 'findFirst' | 'create' | 'update' | 'delete'>;
+type ListRepository = Pick<PrismaClient['shoppingList'], 'findFirst'>;
+type UserRepository = Pick<PrismaClient['user'], 'findUnique'>;
+
+type ItemRoutesDeps = {
+  prisma: {
+    listItem: ItemRepository;
+    shoppingList: ListRepository;
+    user: UserRepository;
+  };
+};
+
+const itemBodySchema = z.object({
+  name: z.string().trim().min(1).max(100),
+  quantity: z.union([z.string().trim().min(1).max(50), z.null()]).optional(),
+  unit: z.union([z.string().trim().min(1).max(50), z.null()]).optional()
+});
+
+const updateItemBodySchema = z.object({
+  name: z.string().trim().min(1).max(100).optional(),
+  quantity: z.union([z.string().trim().min(1).max(50), z.null()]).optional(),
+  unit: z.union([z.string().trim().min(1).max(50), z.null()]).optional(),
+  isChecked: z.boolean().optional()
+});
+
+const defaultDeps = {
+  prisma
+} satisfies ItemRoutesDeps;
+
+function toItemResponse(
+  item: Pick<
+    ListItem,
+    | 'id'
+    | 'listId'
+    | 'name'
+    | 'quantity'
+    | 'unit'
+    | 'isChecked'
+    | 'sortOrder'
+    | 'createdByUserId'
+    | 'createdAt'
+    | 'updatedAt'
+  >
+): ItemResponse {
+  return {
+    id: item.id,
+    listId: item.listId,
+    name: item.name,
+    quantity: item.quantity,
+    unit: item.unit,
+    isChecked: item.isChecked,
+    sortOrder: item.sortOrder,
+    createdByUserId: item.createdByUserId,
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt
+  };
+}
+
+function parseBody<T>(schema: z.ZodType<T>, body: unknown) {
+  const result = schema.safeParse(body);
+
+  if (!result.success) {
+    return null;
+  }
+
+  return result.data;
+}
+
+async function authenticateRequest(
+  deps: ItemRoutesDeps,
+  request: FastifyRequest,
+  reply: FastifyReply
+): Promise<Pick<User, 'id' | 'email' | 'displayName' | 'createdAt' | 'updatedAt'> | null> {
+  const payload = await request.jwtVerify<JwtUserPayload>();
+  const user = await deps.prisma.user.findUnique({
+    where: {
+      id: payload.sub
+    }
+  });
+
+  if (!user) {
+    reply.unauthorized('User not found');
+    return null;
+  }
+
+  return user;
+}
+
+async function findVisibleList(deps: ItemRoutesDeps, userId: string, listId: string) {
+  return deps.prisma.shoppingList.findFirst({
+    where: {
+      id: listId,
+      members: {
+        some: {
+          userId
+        }
+      }
+    }
+  });
+}
+
+async function ensureVisibleList(
+  deps: ItemRoutesDeps,
+  userId: string,
+  listId: string,
+  reply: FastifyReply
+) {
+  const list = await findVisibleList(deps, userId, listId);
+
+  if (!list) {
+    reply.notFound('List not found');
+    return null;
+  }
+
+  return list;
+}
+
+async function findVisibleItem(deps: ItemRoutesDeps, listId: string, itemId: string) {
+  return deps.prisma.listItem.findFirst({
+    where: {
+      id: itemId,
+      listId
+    }
+  });
+}
+
+async function getNextSortOrder(deps: ItemRoutesDeps, listId: string) {
+  const [latestItem] = await deps.prisma.listItem.findMany({
+    where: {
+      listId
+    },
+    orderBy: {
+      sortOrder: 'desc'
+    },
+    take: 1
+  });
+
+  return (latestItem?.sortOrder ?? -1) + 1;
+}
+
+export function createItemRoutes(deps: ItemRoutesDeps = defaultDeps): FastifyPluginAsync {
+  return async (app) => {
+    app.get('/lists/:listId/items', async (request, reply) => {
+      const user = await authenticateRequest(deps, request, reply);
+
+      if (!user) {
+        return;
+      }
+
+      const { listId } = request.params as { listId: string };
+      const list = await ensureVisibleList(deps, user.id, listId, reply);
+
+      if (!list) {
+        return;
+      }
+
+      const items = await deps.prisma.listItem.findMany({
+        where: {
+          listId
+        },
+        orderBy: {
+          sortOrder: 'asc'
+        }
+      });
+
+      return {
+        items: items.map(toItemResponse)
+      };
+    });
+
+    app.post('/lists/:listId/items', async (request, reply) => {
+      const user = await authenticateRequest(deps, request, reply);
+
+      if (!user) {
+        return;
+      }
+
+      const { listId } = request.params as { listId: string };
+      const list = await ensureVisibleList(deps, user.id, listId, reply);
+
+      if (!list) {
+        return;
+      }
+
+      const body = parseBody(itemBodySchema, request.body);
+
+      if (!body) {
+        return reply.badRequest('Invalid request body');
+      }
+
+      const sortOrder = await getNextSortOrder(deps, listId);
+      const item = await deps.prisma.listItem.create({
+        data: {
+          listId,
+          name: body.name,
+          quantity: body.quantity ?? null,
+          unit: body.unit ?? null,
+          isChecked: false,
+          sortOrder,
+          createdByUserId: user.id
+        }
+      });
+
+      return reply.code(201).send({
+        item: toItemResponse(item)
+      });
+    });
+
+    app.patch('/lists/:listId/items/:itemId', async (request, reply) => {
+      const user = await authenticateRequest(deps, request, reply);
+
+      if (!user) {
+        return;
+      }
+
+      const { listId, itemId } = request.params as { listId: string; itemId: string };
+      const list = await ensureVisibleList(deps, user.id, listId, reply);
+
+      if (!list) {
+        return;
+      }
+
+      const body = parseBody(updateItemBodySchema, request.body);
+
+      if (!body) {
+        return reply.badRequest('Invalid request body');
+      }
+
+      if (Object.keys(body).length === 0) {
+        return reply.badRequest('Invalid request body');
+      }
+
+      const existingItem = await findVisibleItem(deps, listId, itemId);
+
+      if (!existingItem) {
+        return reply.notFound('Item not found');
+      }
+
+      const item = await deps.prisma.listItem.update({
+        where: {
+          id: existingItem.id
+        },
+        data: {
+          name: body.name,
+          quantity: body.quantity,
+          unit: body.unit,
+          isChecked: body.isChecked
+        }
+      });
+
+      return {
+        item: toItemResponse(item)
+      };
+    });
+
+    app.delete('/lists/:listId/items/:itemId', async (request, reply) => {
+      const user = await authenticateRequest(deps, request, reply);
+
+      if (!user) {
+        return;
+      }
+
+      const { listId, itemId } = request.params as { listId: string; itemId: string };
+      const list = await ensureVisibleList(deps, user.id, listId, reply);
+
+      if (!list) {
+        return;
+      }
+
+      const existingItem = await findVisibleItem(deps, listId, itemId);
+
+      if (!existingItem) {
+        return reply.notFound('Item not found');
+      }
+
+      await deps.prisma.listItem.delete({
+        where: {
+          id: existingItem.id
+        }
+      });
+
+      return reply.code(204).send();
+    });
+  };
+}
+
+export const itemRoutes = createItemRoutes();

--- a/docs/api.md
+++ b/docs/api.md
@@ -242,7 +242,122 @@ Notes:
 
 ## Items
 
-- `GET /lists/:listId/items`
-- `POST /lists/:listId/items`
-- `PATCH /lists/:listId/items/:itemId`
-- `DELETE /lists/:listId/items/:itemId`
+### `GET /lists/:listId/items`
+
+Headers:
+
+```http
+Authorization: Bearer jwt-token
+```
+
+Response:
+
+```json
+{
+  "items": [
+    {
+      "id": "item_id",
+      "listId": "list_id",
+      "name": "Milk",
+      "quantity": "2",
+      "unit": "l",
+      "isChecked": false,
+      "sortOrder": 0,
+      "createdByUserId": "user_id",
+      "createdAt": "2026-03-29T10:00:00.000Z",
+      "updatedAt": "2026-03-29T10:00:00.000Z"
+    }
+  ]
+}
+```
+
+### `POST /lists/:listId/items`
+
+Headers:
+
+```http
+Authorization: Bearer jwt-token
+```
+
+Request body:
+
+```json
+{
+  "name": "Milk",
+  "quantity": "2",
+  "unit": "l"
+}
+```
+
+Response:
+
+```json
+{
+  "item": {
+    "id": "item_id",
+    "listId": "list_id",
+    "name": "Milk",
+    "quantity": "2",
+    "unit": "l",
+    "isChecked": false,
+    "sortOrder": 0,
+    "createdByUserId": "user_id",
+    "createdAt": "2026-03-29T10:00:00.000Z",
+    "updatedAt": "2026-03-29T10:00:00.000Z"
+  }
+}
+```
+
+Notes:
+- the item is created with the next `sortOrder` value on the server
+- `quantity` and `unit` are optional
+
+### `PATCH /lists/:listId/items/:itemId`
+
+Headers:
+
+```http
+Authorization: Bearer jwt-token
+```
+
+Request body:
+
+```json
+{
+  "name": "Oat milk",
+  "quantity": "2",
+  "unit": "l",
+  "isChecked": true
+}
+```
+
+Response:
+
+```json
+{
+  "item": {
+    "id": "item_id",
+    "listId": "list_id",
+    "name": "Oat milk",
+    "quantity": "2",
+    "unit": "l",
+    "isChecked": true,
+    "sortOrder": 0,
+    "createdByUserId": "user_id",
+    "createdAt": "2026-03-29T10:00:00.000Z",
+    "updatedAt": "2026-03-29T10:00:00.000Z"
+  }
+}
+```
+
+Notes:
+- send only the fields you want to change
+- empty update bodies return `400 Bad Request`
+
+### `DELETE /lists/:listId/items/:itemId`
+
+Headers:
+
+```http
+Authorization: Bearer jwt-token
+```

--- a/docs/mvp-plan.md
+++ b/docs/mvp-plan.md
@@ -47,3 +47,15 @@ The MVP is successful when:
 - both users can add and check items
 - state remains consistent after refresh
 - the system survives backend restarts without losing data
+
+## Status
+
+Completed in this branch:
+- backend auth, lists, sharing, and item CRUD
+- item list/detail flow on mobile with create, edit, delete, and check-off actions
+- refresh-based sync after writes
+
+Remaining for the MVP:
+- mobile auth flow
+- list sharing UI on mobile
+- end-to-end testing on real devices

--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 
+import 'core/network/api_client.dart';
+import 'features/lists/list_detail_page.dart';
+
 class ZakupyApp extends StatelessWidget {
   const ZakupyApp({super.key});
 
@@ -11,10 +14,159 @@ class ZakupyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF2F6B3B)),
         useMaterial3: true
       ),
-      home: const Scaffold(
-        body: Center(
-          child: Text('Zakupy MVP'),
+      home: const _LauncherPage()
+    );
+  }
+}
+
+class _LauncherPage extends StatefulWidget {
+  const _LauncherPage();
+
+  @override
+  State<_LauncherPage> createState() => _LauncherPageState();
+}
+
+class _LauncherPageState extends State<_LauncherPage> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _baseUrlController;
+  late final TextEditingController _accessTokenController;
+  late final TextEditingController _listIdController;
+
+  @override
+  void initState() {
+    super.initState();
+    _baseUrlController = TextEditingController(text: 'http://localhost:3000');
+    _accessTokenController = TextEditingController();
+    _listIdController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _baseUrlController.dispose();
+    _accessTokenController.dispose();
+    _listIdController.dispose();
+    super.dispose();
+  }
+
+  void _openList() {
+    if (!(_formKey.currentState?.validate() ?? false)) {
+      return;
+    }
+
+    final apiClient = ApiClient(
+      baseUrl: _baseUrlController.text,
+      accessToken: _accessTokenController.text.trim()
+    );
+
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (context) => ListDetailPage(
+          apiClient: apiClient,
+          listId: _listIdController.text.trim()
+        )
+      )
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      body: Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [
+              theme.colorScheme.primaryContainer.withOpacity(0.85),
+              theme.colorScheme.surface
+            ]
+          )
         ),
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 420),
+            child: Card(
+              margin: const EdgeInsets.all(24),
+              elevation: 4,
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Form(
+                  key: _formKey,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Text(
+                        'Zakupy',
+                        style: theme.textTheme.headlineMedium
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Connect to your private backend and open a shopping list.',
+                        style: theme.textTheme.bodyMedium
+                      ),
+                      const SizedBox(height: 24),
+                      TextFormField(
+                        controller: _baseUrlController,
+                        decoration: const InputDecoration(
+                          labelText: 'API base URL'
+                        ),
+                        validator: (value) {
+                          final trimmed = value?.trim() ?? '';
+
+                          if (trimmed.isEmpty) {
+                            return 'API base URL is required';
+                          }
+
+                          return null;
+                        }
+                      ),
+                      const SizedBox(height: 12),
+                      TextFormField(
+                        controller: _accessTokenController,
+                        decoration: const InputDecoration(
+                          labelText: 'Access token'
+                        ),
+                        validator: (value) {
+                          final trimmed = value?.trim() ?? '';
+
+                          if (trimmed.isEmpty) {
+                            return 'Access token is required';
+                          }
+
+                          return null;
+                        }
+                      ),
+                      const SizedBox(height: 12),
+                      TextFormField(
+                        controller: _listIdController,
+                        decoration: const InputDecoration(
+                          labelText: 'List ID'
+                        ),
+                        validator: (value) {
+                          final trimmed = value?.trim() ?? '';
+
+                          if (trimmed.isEmpty) {
+                            return 'List ID is required';
+                          }
+
+                          return null;
+                        }
+                      ),
+                      const SizedBox(height: 20),
+                      FilledButton(
+                        onPressed: _openList,
+                        child: const Text('Open list')
+                      )
+                    ]
+                  )
+                )
+              )
+            )
+          )
+        )
       )
     );
   }

--- a/mobile/lib/core/network/api_client.dart
+++ b/mobile/lib/core/network/api_client.dart
@@ -1,3 +1,155 @@
+import 'package:dio/dio.dart';
+
 class ApiClient {
-  const ApiClient();
+  ApiClient({
+    required String baseUrl,
+    required String accessToken,
+    Dio? dio,
+  }) : _dio = dio ??
+            Dio(
+              BaseOptions(
+                baseUrl: _normalizeBaseUrl(baseUrl),
+                headers: {
+                  'Authorization': 'Bearer $accessToken',
+                  'Content-Type': 'application/json'
+                }
+              )
+            );
+
+  final Dio _dio;
+
+  Future<List<ShoppingListItem>> fetchItems(String listId) async {
+    final response = await _dio.get<Map<String, dynamic>>('/lists/$listId/items');
+    final items = (response.data?['items'] as List<dynamic>? ?? const <dynamic>[])
+        .cast<Map<String, dynamic>>();
+
+    return items.map(ShoppingListItem.fromJson).toList(growable: false);
+  }
+
+  Future<ShoppingListItem> createItem(String listId, ItemDraft draft) async {
+    final response = await _dio.post<Map<String, dynamic>>(
+      '/lists/$listId/items',
+      data: draft.toJson()
+    );
+
+    return ShoppingListItem.fromJson(_readObject(response.data, 'item'));
+  }
+
+  Future<ShoppingListItem> updateItem(String listId, String itemId, ItemDraft draft) async {
+    final response = await _dio.patch<Map<String, dynamic>>(
+      '/lists/$listId/items/$itemId',
+      data: draft.toJson()
+    );
+
+    return ShoppingListItem.fromJson(_readObject(response.data, 'item'));
+  }
+
+  Future<void> deleteItem(String listId, String itemId) async {
+    await _dio.delete<void>('/lists/$listId/items/$itemId');
+  }
+
+  static String _normalizeBaseUrl(String baseUrl) {
+    return baseUrl.trim().replaceAll(RegExp(r'/$'), '');
+  }
+
+  static Map<String, dynamic> _readObject(Map<String, dynamic>? payload, String key) {
+    final value = payload?[key];
+
+    if (value is Map<String, dynamic>) {
+      return value;
+    }
+
+    if (value is Map) {
+      return Map<String, dynamic>.from(value);
+    }
+
+    throw StateError('Missing $key in API response');
+  }
+}
+
+class ItemDraft {
+  const ItemDraft({
+    required this.name,
+    this.quantity,
+    this.unit,
+    this.isChecked = false
+  });
+
+  final String name;
+  final String? quantity;
+  final String? unit;
+  final bool isChecked;
+
+  ItemDraft copyWith({
+    String? name,
+    String? quantity,
+    String? unit,
+    bool? isChecked
+  }) {
+    return ItemDraft(
+      name: name ?? this.name,
+      quantity: quantity ?? this.quantity,
+      unit: unit ?? this.unit,
+      isChecked: isChecked ?? this.isChecked
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'name': name,
+      'quantity': quantity,
+      'unit': unit,
+      'isChecked': isChecked
+    };
+  }
+}
+
+class ShoppingListItem {
+  const ShoppingListItem({
+    required this.id,
+    required this.listId,
+    required this.name,
+    required this.quantity,
+    required this.unit,
+    required this.isChecked,
+    required this.sortOrder,
+    required this.createdByUserId,
+    required this.createdAt,
+    required this.updatedAt
+  });
+
+  final String id;
+  final String listId;
+  final String name;
+  final String? quantity;
+  final String? unit;
+  final bool isChecked;
+  final int sortOrder;
+  final String createdByUserId;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  factory ShoppingListItem.fromJson(Map<String, dynamic> json) {
+    return ShoppingListItem(
+      id: json['id'] as String,
+      listId: json['listId'] as String,
+      name: json['name'] as String,
+      quantity: json['quantity'] as String?,
+      unit: json['unit'] as String?,
+      isChecked: json['isChecked'] as bool? ?? false,
+      sortOrder: json['sortOrder'] as int? ?? 0,
+      createdByUserId: json['createdByUserId'] as String,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String)
+    );
+  }
+
+  ItemDraft toDraft() {
+    return ItemDraft(
+      name: name,
+      quantity: quantity,
+      unit: unit,
+      isChecked: isChecked
+    );
+  }
 }

--- a/mobile/lib/features/lists/list_detail_page.dart
+++ b/mobile/lib/features/lists/list_detail_page.dart
@@ -1,0 +1,453 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../../core/network/api_client.dart';
+
+class ListDetailPage extends StatefulWidget {
+  const ListDetailPage({
+    required this.apiClient,
+    required this.listId,
+    super.key
+  });
+
+  final ApiClient apiClient;
+  final String listId;
+
+  @override
+  State<ListDetailPage> createState() => _ListDetailPageState();
+}
+
+class _ListDetailPageState extends State<ListDetailPage> {
+  final List<ShoppingListItem> _items = <ShoppingListItem>[];
+
+  bool _isLoading = true;
+  String? _errorMessage;
+  Timer? _refreshTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _reloadItems();
+    _refreshTimer = Timer.periodic(const Duration(seconds: 15), (_) {
+      if (mounted) {
+        _reloadItems(silent: true);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _refreshTimer?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _reloadItems({bool silent = false}) async {
+    if (!silent && mounted) {
+      setState(() {
+        _isLoading = true;
+        _errorMessage = null;
+      });
+    }
+
+    try {
+      final items = await widget.apiClient.fetchItems(widget.listId);
+
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _items
+          ..clear()
+          ..addAll(items);
+        _isLoading = false;
+        _errorMessage = null;
+      });
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _isLoading = false;
+        _errorMessage = error.toString();
+      });
+    }
+  }
+
+  Future<void> _addItem() async {
+    final draft = await showDialog<ItemDraft>(
+      context: context,
+      builder: (context) {
+        return const _ItemEditorDialog();
+      }
+    );
+
+    if (draft == null) {
+      return;
+    }
+
+    try {
+      await widget.apiClient.createItem(widget.listId, draft);
+      await _reloadItems(silent: true);
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Nie udało się dodać pozycji: $error'))
+      );
+    }
+  }
+
+  Future<void> _editItem(ShoppingListItem item) async {
+    final draft = await showDialog<ItemDraft>(
+      context: context,
+      builder: (context) {
+        return _ItemEditorDialog(initialItem: item);
+      }
+    );
+
+    if (draft == null) {
+      return;
+    }
+
+    try {
+      await widget.apiClient.updateItem(widget.listId, item.id, draft);
+      await _reloadItems(silent: true);
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Nie udało się zapisać pozycji: $error'))
+      );
+    }
+  }
+
+  Future<void> _toggleItem(ShoppingListItem item, bool? checked) async {
+    if (checked == null) {
+      return;
+    }
+
+    try {
+      await widget.apiClient.updateItem(
+        widget.listId,
+        item.id,
+        item.toDraft().copyWith(isChecked: checked)
+      );
+      await _reloadItems(silent: true);
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Nie udało się zmienić stanu pozycji: $error'))
+      );
+    }
+  }
+
+  Future<void> _deleteItem(ShoppingListItem item) async {
+    final shouldDelete = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Delete item'),
+          content: Text('Delete "${item.name}"?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('Cancel')
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('Delete')
+            )
+          ]
+        );
+      }
+    );
+
+    if (shouldDelete != true) {
+      return;
+    }
+
+    try {
+      await widget.apiClient.deleteItem(widget.listId, item.id);
+      await _reloadItems(silent: true);
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Nie udało się usunąć pozycji: $error'))
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Lista ${widget.listId}'),
+        actions: [
+          IconButton(
+            onPressed: () => _reloadItems(),
+            icon: const Icon(Icons.refresh)
+          )
+        ]
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _addItem,
+        child: const Icon(Icons.add)
+      ),
+      body: RefreshIndicator(
+        onRefresh: () => _reloadItems(silent: true),
+        child: _buildBody(context)
+      )
+    );
+  }
+
+  Widget _buildBody(BuildContext context) {
+    if (_isLoading && _items.isEmpty) {
+      return ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: const [
+          SizedBox(height: 240),
+          Center(
+            child: CircularProgressIndicator()
+          )
+        ]
+      );
+    }
+
+    if (_errorMessage != null && _items.isEmpty) {
+      return ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          const SizedBox(height: 160),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: Column(
+              children: [
+                const Icon(Icons.error_outline, size: 48),
+                const SizedBox(height: 12),
+                Text(
+                  'Nie udało się pobrać pozycji',
+                  style: Theme.of(context).textTheme.titleMedium
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  _errorMessage ?? 'Unknown error',
+                  textAlign: TextAlign.center
+                ),
+                const SizedBox(height: 16),
+                FilledButton(
+                  onPressed: () => _reloadItems(),
+                  child: const Text('Retry')
+                )
+              ]
+            )
+          )
+        ]
+      );
+    }
+
+    if (_items.isEmpty) {
+      return ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: const [
+          SizedBox(height: 160),
+          Center(
+            child: Text('No items yet. Add the first one.')
+          )
+        ]
+      );
+    }
+
+    return ListView.separated(
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 96),
+      itemCount: _items.length,
+      separatorBuilder: (context, index) => const SizedBox(height: 8),
+      itemBuilder: (context, index) {
+        final item = _items[index];
+
+        return Card(
+          child: ListTile(
+            leading: Checkbox(
+              value: item.isChecked,
+              onChanged: (checked) => _toggleItem(item, checked)
+            ),
+            title: Text(
+              item.name,
+              style: TextStyle(
+                decoration: item.isChecked ? TextDecoration.lineThrough : TextDecoration.none
+              )
+            ),
+            subtitle: _buildSubtitle(item),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                IconButton(
+                  onPressed: () => _editItem(item),
+                  icon: const Icon(Icons.edit_outlined)
+                ),
+                IconButton(
+                  onPressed: () => _deleteItem(item),
+                  icon: const Icon(Icons.delete_outline)
+                )
+              ]
+            )
+          )
+        );
+      }
+    );
+  }
+
+  Widget? _buildSubtitle(ShoppingListItem item) {
+    final details = <String>[];
+
+    if (item.quantity != null && item.quantity!.isNotEmpty) {
+      details.add(item.quantity!);
+    }
+
+    if (item.unit != null && item.unit!.isNotEmpty) {
+      details.add(item.unit!);
+    }
+
+    if (details.isEmpty) {
+      return null;
+    }
+
+    return Text(details.join(' '));
+  }
+}
+
+class _ItemEditorDialog extends StatefulWidget {
+  const _ItemEditorDialog({this.initialItem});
+
+  final ShoppingListItem? initialItem;
+
+  @override
+  State<_ItemEditorDialog> createState() => _ItemEditorDialogState();
+}
+
+class _ItemEditorDialogState extends State<_ItemEditorDialog> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _nameController;
+  late final TextEditingController _quantityController;
+  late final TextEditingController _unitController;
+  late bool _isChecked;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.initialItem?.name ?? '');
+    _quantityController = TextEditingController(text: widget.initialItem?.quantity ?? '');
+    _unitController = TextEditingController(text: widget.initialItem?.unit ?? '');
+    _isChecked = widget.initialItem?.isChecked ?? false;
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _quantityController.dispose();
+    _unitController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    if (!(_formKey.currentState?.validate() ?? false)) {
+      return;
+    }
+
+    Navigator.of(context).pop(
+      ItemDraft(
+        name: _nameController.text.trim(),
+        quantity: _normalizedOptionalText(_quantityController.text),
+        unit: _normalizedOptionalText(_unitController.text),
+        isChecked: _isChecked
+      )
+    );
+  }
+
+  String? _normalizedOptionalText(String value) {
+    final trimmed = value.trim();
+
+    if (trimmed.isEmpty) {
+      return null;
+    }
+
+    return trimmed;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isEditing = widget.initialItem != null;
+
+    return AlertDialog(
+      title: Text(isEditing ? 'Edit item' : 'Add item'),
+      content: SingleChildScrollView(
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(labelText: 'Name'),
+                textInputAction: TextInputAction.next,
+                validator: (value) {
+                  final trimmed = value?.trim() ?? '';
+
+                  if (trimmed.isEmpty) {
+                    return 'Name is required';
+                  }
+
+                  return null;
+                }
+              ),
+              TextFormField(
+                controller: _quantityController,
+                decoration: const InputDecoration(labelText: 'Quantity'),
+                textInputAction: TextInputAction.next
+              ),
+              TextFormField(
+                controller: _unitController,
+                decoration: const InputDecoration(labelText: 'Unit'),
+                textInputAction: TextInputAction.done,
+                onFieldSubmitted: (_) => _submit()
+              ),
+              SwitchListTile(
+                contentPadding: EdgeInsets.zero,
+                title: const Text('Checked'),
+                value: _isChecked,
+                onChanged: (value) {
+                  setState(() {
+                    _isChecked = value;
+                  });
+                }
+              )
+            ]
+          )
+        )
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel')
+        ),
+        FilledButton(
+          onPressed: _submit,
+          child: const Text('Save')
+        )
+      ]
+    );
+  }
+}

--- a/mobile/test/api_client_test.dart
+++ b/mobile/test/api_client_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:zakupy_mobile/core/network/api_client.dart';
+
+void main() {
+  test('ShoppingListItem.fromJson parses API payloads', () {
+    final item = ShoppingListItem.fromJson({
+      'id': 'item_1',
+      'listId': 'list_1',
+      'name': 'Milk',
+      'quantity': '2',
+      'unit': 'l',
+      'isChecked': true,
+      'sortOrder': 3,
+      'createdByUserId': 'user_1',
+      'createdAt': '2026-03-30T10:00:00.000Z',
+      'updatedAt': '2026-03-30T10:00:00.000Z'
+    });
+
+    expect(item.id, 'item_1');
+    expect(item.listId, 'list_1');
+    expect(item.name, 'Milk');
+    expect(item.quantity, '2');
+    expect(item.unit, 'l');
+    expect(item.isChecked, true);
+    expect(item.sortOrder, 3);
+    expect(item.createdByUserId, 'user_1');
+  });
+
+  test('ShoppingListItem.toDraft and ItemDraft.toJson preserve nullable fields', () {
+    final item = ShoppingListItem(
+      id: 'item_1',
+      listId: 'list_1',
+      name: 'Bread',
+      quantity: null,
+      unit: 'pcs',
+      isChecked: false,
+      sortOrder: 1,
+      createdByUserId: 'user_1',
+      createdAt: DateTime(2026, 3, 30, 10),
+      updatedAt: DateTime(2026, 3, 30, 10)
+    );
+
+    expect(item.toDraft().toJson(), {
+      'name': 'Bread',
+      'quantity': null,
+      'unit': 'pcs',
+      'isChecked': false
+    });
+  });
+
+  test('ItemDraft.copyWith keeps existing values by default', () {
+    const draft = ItemDraft(
+      name: 'Milk',
+      quantity: '1',
+      unit: 'l',
+      isChecked: false
+    );
+
+    final updated = draft.copyWith(isChecked: true);
+
+    expect(updated.name, 'Milk');
+    expect(updated.quantity, '1');
+    expect(updated.unit, 'l');
+    expect(updated.isChecked, true);
+  });
+}


### PR DESCRIPTION
## What changed
- Implemented full shopping item CRUD on the Fastify backend.
- Added backend tests for list visibility, create, update, delete, invalid payloads, and ordering.
- Added a mobile list-detail screen with add/edit/delete/check-off actions and refresh-based sync.
- Added a simple launcher screen so the app can connect to a backend base URL, token, and list ID.
- Updated the MVP plan and API docs to reflect the completed work.

## Validation
- `npm test` in `backend/`
- `npm run build` in `backend/`

## Notes
- Flutter SDK is not installed in this environment, so the mobile app could not be run locally here.
- `gh auth status` is currently invalid in this environment, so the PR was opened through the GitHub connector after pushing the branch.