### PR TITLE
Optimistic UI and mutation tracking for list item operations

### DIFF
--- a/mobile/lib/features/lists/list_detail_page.dart
+++ b/mobile/lib/features/lists/list_detail_page.dart
@@ -24,6 +24,8 @@ class ListDetailPage extends StatefulWidget {
 
 class _ListDetailPageState extends State<ListDetailPage> {
   final List<ShoppingListItem> _items = <ShoppingListItem>[];
+  final Set<String> _pendingItemIds = <String>{};
+  final Map<String, int> _itemMutationVersions = <String, int>{};
 
   bool _isLoading = true;
   bool _isSharing = false;
@@ -66,6 +68,8 @@ class _ListDetailPageState extends State<ListDetailPage> {
         _items
           ..clear()
           ..addAll(items);
+        _itemMutationVersions.clear();
+        _pendingItemIds.clear();
         _isLoading = false;
         _errorMessage = null;
       });
@@ -98,10 +102,38 @@ class _ListDetailPageState extends State<ListDetailPage> {
       return;
     }
 
+    final temporaryId = '_tmp_${DateTime.now().microsecondsSinceEpoch}';
+    final now = DateTime.now();
+    final temporaryItem = ShoppingListItem(
+      id: temporaryId,
+      listId: widget.listId,
+      name: draft.name,
+      quantity: draft.quantity,
+      unit: draft.unit,
+      isChecked: draft.isChecked,
+      sortOrder: _nextSortOrder(),
+      createdByUserId: '',
+      createdAt: now,
+      updatedAt: now,
+    );
+
+    final mutationVersion = _beginItemMutation(temporaryId);
+    if (mounted) {
+      setState(() {
+        _items.add(temporaryItem);
+      });
+    }
+
     try {
       await widget.apiClient.createItem(widget.listId, draft);
       await _reloadItems(silent: true);
     } on ApiException catch (error) {
+      if (mounted && _isCurrentMutation(temporaryId, mutationVersion)) {
+        setState(() {
+          _items.removeWhere((item) => item.id == temporaryId);
+        });
+      }
+
       if (error.isUnauthorized && widget.onUnauthorized != null) {
         await widget.onUnauthorized!();
         return;
@@ -110,10 +142,11 @@ class _ListDetailPageState extends State<ListDetailPage> {
       if (!mounted) {
         return;
       }
-
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Could not add item: ${error.message}')),
       );
+    } finally {
+      _finishItemMutation(temporaryId, mutationVersion);
     }
   }
 
@@ -129,10 +162,19 @@ class _ListDetailPageState extends State<ListDetailPage> {
       return;
     }
 
+    final previousItem = item;
+    final optimisticItem = _itemFromDraft(item: item, draft: draft);
+    final mutationVersion = _beginItemMutation(item.id);
+    _replaceItemOptimistically(optimisticItem);
+
     try {
       await widget.apiClient.updateItem(widget.listId, item.id, draft);
       await _reloadItems(silent: true);
     } on ApiException catch (error) {
+      if (_isCurrentMutation(item.id, mutationVersion)) {
+        _replaceItemOptimistically(previousItem);
+      }
+
       if (error.isUnauthorized && widget.onUnauthorized != null) {
         await widget.onUnauthorized!();
         return;
@@ -145,6 +187,8 @@ class _ListDetailPageState extends State<ListDetailPage> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Could not save item: ${error.message}')),
       );
+    } finally {
+      _finishItemMutation(item.id, mutationVersion);
     }
   }
 
@@ -152,6 +196,14 @@ class _ListDetailPageState extends State<ListDetailPage> {
     if (checked == null) {
       return;
     }
+
+    final previousItem = item;
+    final optimisticItem = _itemFromDraft(
+      item: item,
+      draft: item.toDraft().copyWith(isChecked: checked),
+    );
+    final mutationVersion = _beginItemMutation(item.id);
+    _replaceItemOptimistically(optimisticItem);
 
     try {
       await widget.apiClient.updateItem(
@@ -161,6 +213,10 @@ class _ListDetailPageState extends State<ListDetailPage> {
       );
       await _reloadItems(silent: true);
     } on ApiException catch (error) {
+      if (_isCurrentMutation(item.id, mutationVersion)) {
+        _replaceItemOptimistically(previousItem);
+      }
+
       if (error.isUnauthorized && widget.onUnauthorized != null) {
         await widget.onUnauthorized!();
         return;
@@ -173,6 +229,8 @@ class _ListDetailPageState extends State<ListDetailPage> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Could not update item: ${error.message}')),
       );
+    } finally {
+      _finishItemMutation(item.id, mutationVersion);
     }
   }
 
@@ -201,10 +259,26 @@ class _ListDetailPageState extends State<ListDetailPage> {
       return;
     }
 
+    final previousItems = List<ShoppingListItem>.from(_items);
+    final mutationVersion = _beginItemMutation(item.id);
+    if (mounted) {
+      setState(() {
+        _items.removeWhere((current) => current.id == item.id);
+      });
+    }
+
     try {
       await widget.apiClient.deleteItem(widget.listId, item.id);
       await _reloadItems(silent: true);
     } on ApiException catch (error) {
+      if (mounted && _isCurrentMutation(item.id, mutationVersion)) {
+        setState(() {
+          _items
+            ..clear()
+            ..addAll(previousItems);
+        });
+      }
+
       if (error.isUnauthorized && widget.onUnauthorized != null) {
         await widget.onUnauthorized!();
         return;
@@ -217,7 +291,90 @@ class _ListDetailPageState extends State<ListDetailPage> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Could not delete item: ${error.message}')),
       );
+    } finally {
+      _finishItemMutation(item.id, mutationVersion);
     }
+  }
+
+  int _nextSortOrder() {
+    if (_items.isEmpty) {
+      return 0;
+    }
+
+    final maxSortOrder = _items
+        .map((item) => item.sortOrder)
+        .reduce((current, next) => current > next ? current : next);
+    return maxSortOrder + 1;
+  }
+
+  ShoppingListItem _itemFromDraft({
+    required ShoppingListItem item,
+    required ItemDraft draft,
+  }) {
+    return ShoppingListItem(
+      id: item.id,
+      listId: item.listId,
+      name: draft.name,
+      quantity: draft.quantity,
+      unit: draft.unit,
+      isChecked: draft.isChecked,
+      sortOrder: item.sortOrder,
+      createdByUserId: item.createdByUserId,
+      createdAt: item.createdAt,
+      updatedAt: DateTime.now(),
+    );
+  }
+
+  void _replaceItemOptimistically(ShoppingListItem updatedItem) {
+    if (!mounted) {
+      return;
+    }
+
+    final index = _items.indexWhere((item) => item.id == updatedItem.id);
+    if (index < 0) {
+      return;
+    }
+
+    setState(() {
+      _items[index] = updatedItem;
+    });
+  }
+
+  int _beginItemMutation(String itemId) {
+    final version = (_itemMutationVersions[itemId] ?? 0) + 1;
+
+    if (mounted) {
+      setState(() {
+        _itemMutationVersions[itemId] = version;
+        _pendingItemIds.add(itemId);
+      });
+    } else {
+      _itemMutationVersions[itemId] = version;
+      _pendingItemIds.add(itemId);
+    }
+
+    return version;
+  }
+
+  bool _isCurrentMutation(String itemId, int version) {
+    return _itemMutationVersions[itemId] == version;
+  }
+
+  void _finishItemMutation(String itemId, int version) {
+    if (!_isCurrentMutation(itemId, version)) {
+      return;
+    }
+
+    if (mounted) {
+      setState(() {
+        _itemMutationVersions.remove(itemId);
+        _pendingItemIds.remove(itemId);
+      });
+      return;
+    }
+
+    _itemMutationVersions.remove(itemId);
+    _pendingItemIds.remove(itemId);
   }
 
   Future<void> _shareList() async {
@@ -392,10 +549,15 @@ class _ListDetailPageState extends State<ListDetailPage> {
         final item = _items[index];
 
         return Card(
+          color: _pendingItemIds.contains(item.id)
+              ? Theme.of(context).colorScheme.surfaceContainerHighest
+              : null,
           child: ListTile(
             leading: Checkbox(
               value: item.isChecked,
-              onChanged: (checked) => _toggleItem(item, checked),
+              onChanged: _pendingItemIds.contains(item.id)
+                  ? null
+                  : (checked) => _toggleItem(item, checked),
             ),
             title: Text(
               item.name,
@@ -409,11 +571,14 @@ class _ListDetailPageState extends State<ListDetailPage> {
               mainAxisSize: MainAxisSize.min,
               children: [
                 IconButton(
-                  onPressed: () => _editItem(item),
+                  onPressed:
+                      _pendingItemIds.contains(item.id) ? null : () => _editItem(item),
                   icon: const Icon(Icons.edit_outlined),
                 ),
                 IconButton(
-                  onPressed: () => _deleteItem(item),
+                  onPressed: _pendingItemIds.contains(item.id)
+                      ? null
+                      : () => _deleteItem(item),
                   icon: const Icon(Icons.delete_outline),
                 ),
               ],


### PR DESCRIPTION
### Motivation
- Provide immediate feedback for create/update/toggle/delete item operations to improve perceived performance by applying optimistic UI updates.
- Prevent conflicting or stale state updates from async races by tracking mutation versions per item and disabling controls while operations are pending.
- Ensure temporary items for creates and optimistic edits are reconciled with server state or reverted on failure.

### Description
- Add `_pendingItemIds` and `_itemMutationVersions` to track in-flight mutations and their versions and clear them on full reload via `_reloadItems`.
- Implement optimistic create using a temporary id (prefixed `_tmp_`) and add the temporary item to `_items` while the create request is in-flight, then remove it on failure or refresh on success.
- Add optimistic update/toggle flows that replace the item locally via `_replaceItemOptimistically` and restore the previous item if the mutation fails, guarded by `_beginItemMutation`, `_isCurrentMutation`, and `_finishItemMutation` to avoid race conditions.
- Disable item controls (`edit`, `delete`, `checkbox`) and visually mark pending items by checking `_pendingItemIds` and changing the card color while a mutation is pending.
- Add helpers ` _nextSortOrder`, `_itemFromDraft`, and utility functions for mutation lifecycle management.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd856750808324a61175fe4338fe3d)