### PR TITLE
Optimistic item mutations and pending-state handling in ListDetailPage

### DIFF
--- a/mobile/lib/features/lists/list_detail_page.dart
+++ b/mobile/lib/features/lists/list_detail_page.dart
@@ -24,6 +24,8 @@ class ListDetailPage extends StatefulWidget {
 
 class _ListDetailPageState extends State<ListDetailPage> {
   final List<ShoppingListItem> _items = <ShoppingListItem>[];
+  final Set<String> _pendingItemIds = <String>{};
+  final Map<String, int> _itemMutationVersions = <String, int>{};
 
   bool _isLoading = true;
   bool _isSharing = false;
@@ -35,7 +37,7 @@ class _ListDetailPageState extends State<ListDetailPage> {
     super.initState();
     _reloadItems();
     _refreshTimer = Timer.periodic(const Duration(seconds: 15), (_) {
-      if (mounted) {
+      if (mounted && _pendingItemIds.isEmpty) {
         _reloadItems(silent: true);
       }
     });
@@ -98,10 +100,38 @@ class _ListDetailPageState extends State<ListDetailPage> {
       return;
     }
 
+    final temporaryId = '_tmp_${DateTime.now().microsecondsSinceEpoch}';
+    final now = DateTime.now();
+    final temporaryItem = ShoppingListItem(
+      id: temporaryId,
+      listId: widget.listId,
+      name: draft.name,
+      quantity: draft.quantity,
+      unit: draft.unit,
+      isChecked: draft.isChecked,
+      sortOrder: _nextSortOrder(),
+      createdByUserId: '',
+      createdAt: now,
+      updatedAt: now,
+    );
+
+    final mutationVersion = _beginItemMutation(temporaryId);
+    if (mounted) {
+      setState(() {
+        _items.add(temporaryItem);
+      });
+    }
+
     try {
       await widget.apiClient.createItem(widget.listId, draft);
       await _reloadItems(silent: true);
     } on ApiException catch (error) {
+      if (mounted && _isCurrentMutation(temporaryId, mutationVersion)) {
+        setState(() {
+          _items.removeWhere((item) => item.id == temporaryId);
+        });
+      }
+
       if (error.isUnauthorized && widget.onUnauthorized != null) {
         await widget.onUnauthorized!();
         return;
@@ -110,10 +140,11 @@ class _ListDetailPageState extends State<ListDetailPage> {
       if (!mounted) {
         return;
       }
-
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Could not add item: ${error.message}')),
       );
+    } finally {
+      _finishItemMutation(temporaryId, mutationVersion);
     }
   }
 
@@ -129,10 +160,19 @@ class _ListDetailPageState extends State<ListDetailPage> {
       return;
     }
 
+    final previousItem = item;
+    final optimisticItem = _itemFromDraft(item: item, draft: draft);
+    final mutationVersion = _beginItemMutation(item.id);
+    _replaceItemOptimistically(optimisticItem);
+
     try {
       await widget.apiClient.updateItem(widget.listId, item.id, draft);
       await _reloadItems(silent: true);
     } on ApiException catch (error) {
+      if (_isCurrentMutation(item.id, mutationVersion)) {
+        _replaceItemOptimistically(previousItem);
+      }
+
       if (error.isUnauthorized && widget.onUnauthorized != null) {
         await widget.onUnauthorized!();
         return;
@@ -145,6 +185,8 @@ class _ListDetailPageState extends State<ListDetailPage> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Could not save item: ${error.message}')),
       );
+    } finally {
+      _finishItemMutation(item.id, mutationVersion);
     }
   }
 
@@ -152,6 +194,14 @@ class _ListDetailPageState extends State<ListDetailPage> {
     if (checked == null) {
       return;
     }
+
+    final previousItem = item;
+    final optimisticItem = _itemFromDraft(
+      item: item,
+      draft: item.toDraft().copyWith(isChecked: checked),
+    );
+    final mutationVersion = _beginItemMutation(item.id);
+    _replaceItemOptimistically(optimisticItem);
 
     try {
       await widget.apiClient.updateItem(
@@ -161,6 +211,10 @@ class _ListDetailPageState extends State<ListDetailPage> {
       );
       await _reloadItems(silent: true);
     } on ApiException catch (error) {
+      if (_isCurrentMutation(item.id, mutationVersion)) {
+        _replaceItemOptimistically(previousItem);
+      }
+
       if (error.isUnauthorized && widget.onUnauthorized != null) {
         await widget.onUnauthorized!();
         return;
@@ -173,6 +227,8 @@ class _ListDetailPageState extends State<ListDetailPage> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Could not update item: ${error.message}')),
       );
+    } finally {
+      _finishItemMutation(item.id, mutationVersion);
     }
   }
 
@@ -201,10 +257,26 @@ class _ListDetailPageState extends State<ListDetailPage> {
       return;
     }
 
+    final previousItems = List<ShoppingListItem>.from(_items);
+    final mutationVersion = _beginItemMutation(item.id);
+    if (mounted) {
+      setState(() {
+        _items.removeWhere((current) => current.id == item.id);
+      });
+    }
+
     try {
       await widget.apiClient.deleteItem(widget.listId, item.id);
       await _reloadItems(silent: true);
     } on ApiException catch (error) {
+      if (mounted && _isCurrentMutation(item.id, mutationVersion)) {
+        setState(() {
+          _items
+            ..clear()
+            ..addAll(previousItems);
+        });
+      }
+
       if (error.isUnauthorized && widget.onUnauthorized != null) {
         await widget.onUnauthorized!();
         return;
@@ -217,7 +289,90 @@ class _ListDetailPageState extends State<ListDetailPage> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Could not delete item: ${error.message}')),
       );
+    } finally {
+      _finishItemMutation(item.id, mutationVersion);
     }
+  }
+
+  int _nextSortOrder() {
+    if (_items.isEmpty) {
+      return 0;
+    }
+
+    final maxSortOrder = _items
+        .map((item) => item.sortOrder)
+        .reduce((current, next) => current > next ? current : next);
+    return maxSortOrder + 1;
+  }
+
+  ShoppingListItem _itemFromDraft({
+    required ShoppingListItem item,
+    required ItemDraft draft,
+  }) {
+    return ShoppingListItem(
+      id: item.id,
+      listId: item.listId,
+      name: draft.name,
+      quantity: draft.quantity,
+      unit: draft.unit,
+      isChecked: draft.isChecked,
+      sortOrder: item.sortOrder,
+      createdByUserId: item.createdByUserId,
+      createdAt: item.createdAt,
+      updatedAt: DateTime.now(),
+    );
+  }
+
+  void _replaceItemOptimistically(ShoppingListItem updatedItem) {
+    if (!mounted) {
+      return;
+    }
+
+    final index = _items.indexWhere((item) => item.id == updatedItem.id);
+    if (index < 0) {
+      return;
+    }
+
+    setState(() {
+      _items[index] = updatedItem;
+    });
+  }
+
+  int _beginItemMutation(String itemId) {
+    final version = (_itemMutationVersions[itemId] ?? 0) + 1;
+
+    if (mounted) {
+      setState(() {
+        _itemMutationVersions[itemId] = version;
+        _pendingItemIds.add(itemId);
+      });
+    } else {
+      _itemMutationVersions[itemId] = version;
+      _pendingItemIds.add(itemId);
+    }
+
+    return version;
+  }
+
+  bool _isCurrentMutation(String itemId, int version) {
+    return _itemMutationVersions[itemId] == version;
+  }
+
+  void _finishItemMutation(String itemId, int version) {
+    if (!_isCurrentMutation(itemId, version)) {
+      return;
+    }
+
+    if (mounted) {
+      setState(() {
+        _itemMutationVersions.remove(itemId);
+        _pendingItemIds.remove(itemId);
+      });
+      return;
+    }
+
+    _itemMutationVersions.remove(itemId);
+    _pendingItemIds.remove(itemId);
   }
 
   Future<void> _shareList() async {
@@ -392,10 +547,15 @@ class _ListDetailPageState extends State<ListDetailPage> {
         final item = _items[index];
 
         return Card(
+          color: _pendingItemIds.contains(item.id)
+              ? Theme.of(context).colorScheme.surfaceContainerHighest
+              : null,
           child: ListTile(
             leading: Checkbox(
               value: item.isChecked,
-              onChanged: (checked) => _toggleItem(item, checked),
+              onChanged: _pendingItemIds.contains(item.id)
+                  ? null
+                  : (checked) => _toggleItem(item, checked),
             ),
             title: Text(
               item.name,
@@ -409,11 +569,14 @@ class _ListDetailPageState extends State<ListDetailPage> {
               mainAxisSize: MainAxisSize.min,
               children: [
                 IconButton(
-                  onPressed: () => _editItem(item),
+                  onPressed:
+                      _pendingItemIds.contains(item.id) ? null : () => _editItem(item),
                   icon: const Icon(Icons.edit_outlined),
                 ),
                 IconButton(
-                  onPressed: () => _deleteItem(item),
+                  onPressed: _pendingItemIds.contains(item.id)
+                      ? null
+                      : () => _deleteItem(item),
                   icon: const Icon(Icons.delete_outline),
                 ),
               ],


### PR DESCRIPTION
### Motivation

- Improve responsiveness by applying optimistic updates for add, edit, toggle, and delete item operations. 
- Prevent background refreshes from overwriting in-flight mutations by tracking pending item mutations. 
- Provide clear UX feedback and prevent duplicate changes by disabling controls and visually marking items with pending mutations.

### Description

- Added mutation tracking fields `_pendingItemIds` and `_itemMutationVersions` and helper methods `
_beginItemMutation`, `_isCurrentMutation`, and `_finishItemMutation` to manage in-flight mutations.  
- Implemented optimistic add via a temporary item with a `'_tmp_<timestamp>'` id in `_addItem`, and revert/remove the temporary item on error.  
- Implemented optimistic replace behavior for `_editItem` and `_toggleItem` using `_itemFromDraft` and `_replaceItemOptimistically`, and revert to the previous item when mutations fail.  
- Implemented optimistic delete by removing the item locally and restoring the previous list on failure, and added `_nextSortOrder` for local sort order assignment.  
- Prevent periodic refresh from running while there are pending mutations and disable item controls (edit, delete, checkbox) for items in `_pendingItemIds`, while also applying a visual highlight using `surfaceContainerHighest` for pending items.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd856750808324a61175fe4338fe3d)