### PR TITLE
[codex] sync docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ Prywatna aplikacja zakupowa dla dwóch użytkowników. Projekt celuje w prosty, 
 - wdrożenie na domowym VM przez Docker Compose
 - dostęp prywatny przez Tailscale i reverse proxy Caddy
 
+## Aktualny stan
+
+W kodzie są już dostępne:
+- logowanie i rejestracja z sesją JWT
+- przywracanie sesji po starcie aplikacji mobilnej
+- widok list i widok szczegółów listy
+- tworzenie list
+- współdzielenie list z innym użytkownikiem
+- dodawanie, edycja, usuwanie i odhaczanie pozycji
+- odświeżanie danych po zapisie oraz okresowy refresh w widoku szczegółów listy
+
 ## Struktura repozytorium
 
 ```text
@@ -14,7 +25,7 @@ Prywatna aplikacja zakupowa dla dwóch użytkowników. Projekt celuje w prosty, 
 ├── backend/   # API Fastify, Prisma, TypeScript
 ├── docs/      # architektura, plan MVP, API, notatki operacyjne
 ├── infra/     # docker-compose, Caddyfile, deployment notes
-└── mobile/    # starter aplikacji Flutter
+└── mobile/    # aplikacja Flutter
 ```
 
 ## Szybki start
@@ -67,7 +78,7 @@ cp .env.example .env
 docker compose up --build -d
 ```
 
-W [infra/.env.example](/Users/piotr/sandbox/Zakupy/infra/.env.example) masz wszystkie zmienne do lokalnego uruchomienia, w tym `JWT_SECRET`. Ustaw tam własną wartość w `infra/.env`, zamiast trzymać sekret na sztywno w Compose.
+W [infra/.env.example](infra/.env.example) masz wszystkie zmienne do lokalnego uruchomienia, w tym `JWT_SECRET`. Ustaw tam własną wartość w `infra/.env`, zamiast trzymać sekret na sztywno w Compose.
 
 ### 2. Backend bez Dockera
 
@@ -83,23 +94,23 @@ API wystartuje domyślnie na `http://localhost:3000`.
 
 ### 3. Mobile
 
-`mobile/` zawiera starter struktury Flutter, ale nie jest wygenerowany przez `flutter create`, bo `flutter` nie jest dostępny w tym środowisku. Gdy będziesz mieć Flutter SDK lokalnie:
+`mobile/` zawiera obecny kod Fluttera. Jeśli potrzebujesz odtworzyć brakujące pliki platformowe lokalnie:
 
 ```bash
 cd mobile
 flutter create .
 ```
 
-Po tym zachowaj istniejący układ `lib/` i dopasuj wygenerowane pliki platformowe.
+Po wygenerowaniu zachowaj istniejący układ `lib/` i dopasuj pliki platformowe do tego kodu.
 
 ### 4. Flutter i backend razem
 
 Najprostszy lokalny flow:
 
-1. W jednym terminalu uruchom `docker compose up --build -d postgres backend` w [infra/](/Users/piotr/sandbox/Zakupy/infra).
+1. W jednym terminalu uruchom `docker compose up --build -d postgres backend` w [infra/](infra).
 2. Sprawdź `curl http://localhost:3000/health`.
 3. Wyślij `POST /auth/register`, żeby potwierdzić zapis do Postgresa.
-4. W [mobile/](/Users/piotr/sandbox/Zakupy/mobile) wykonaj `flutter create .`, potem `flutter pub get`.
+4. W [mobile/](mobile) wykonaj `flutter create .`, potem `flutter pub get`.
 5. Uruchom `flutter run --dart-define=API_BASE_URL=https://twoj-host.tailnet.ts.net` na simulatorze iOS albo emulatorze Android.
 
 Na prawdziwych urządzeniach nie używaj `localhost` jako API URL. Telefon powinien łączyć się z backendem przez adres Tailscale/Caddy dostępny w sieci urządzenia, najlepiej po HTTPS.
@@ -113,10 +124,10 @@ Zakres pierwszej wersji:
 - dodawanie, edycja, usuwanie i odhaczanie pozycji
 - prosty sync oparty o odświeżanie danych po zapisie
 
+To już pokrywa obecna implementacja backendu i mobile. Następne rozsądne kroki to dopięcie pełnego testowania end-to-end oraz dalsze uspójnianie UX pod użycie na dwóch realnych telefonach.
+
 ## Najbliższe kroki
 
-1. Zainstalować zależności backendu i wykonać pierwszą migrację Prisma.
-2. Dokończyć moduł auth z Argon2 i JWT.
-3. Dodać CRUD list, członkostwa i pozycji.
-4. Wygenerować pełny projekt Flutter przez `flutter create .` w `mobile/`.
-5. Spiąć mobile z backendem przez REST.
+1. Dopięcie pełnego testowania end-to-end na dwóch realnych urządzeniach.
+2. Wyczyszczenie UX po wspólnym użyciu z drugą osobą.
+3. Rozszerzenie mobile o zarządzanie listami poza tworzeniem i współdzieleniem, jeśli okaże się to potrzebne w codziennym użyciu.

--- a/docs/mvp-plan.md
+++ b/docs/mvp-plan.md
@@ -50,12 +50,16 @@ The MVP is successful when:
 
 ## Status
 
-Completed in this branch:
-- backend auth, lists, sharing, and item CRUD
-- mobile auth foundation with session persistence
-- item list/detail flow on mobile with create, edit, delete, and check-off actions
+Implemented in the current codebase:
+- backend auth, list CRUD, sharing, and item CRUD
+- mobile auth foundation with session persistence and session restore on launch
+- list overview and detail flow on mobile
+- list sharing by email from the mobile UI
+- item create, edit, delete, and check-off actions on mobile
 - refresh-based sync after writes
+- periodic background refresh in the item detail view
 
-Remaining for the MVP:
-- list sharing UI on mobile
+Still worth doing before calling the MVP done:
 - end-to-end testing on real devices
+- basic smoke testing of the share flow with two real accounts
+- UX polish after hands-on use

--- a/mobile/lib/features/auth/README.md
+++ b/mobile/lib/features/auth/README.md
@@ -3,4 +3,5 @@
 Implemented flow:
 - login and registration against the Fastify API
 - JWT session persistence in `flutter_secure_storage`
-- auto-restore of a saved session on app launch
+- auto-restore of a saved session on app launch through `/auth/me`
+- API base URL selection per device, so each phone can point at the right home backend

--- a/mobile/lib/features/lists/README.md
+++ b/mobile/lib/features/lists/README.md
@@ -1,7 +1,14 @@
 # Lists feature
 
-Docelowo:
-- widok list
-- tworzenie list
-- współdzielenie list
-- widok pozycji
+Current mobile flow:
+- list overview page that loads `/lists` and supports pull-to-refresh
+- create-list action from the authenticated home screen
+- list detail page with item list, add, edit, delete, and check-off actions
+- share-list action by email from the detail screen
+- optimistic updates with reconciliation after server writes
+- periodic refresh in the detail view to catch changes from the other user
+
+Backend capabilities that already exist but are not fully exposed in the mobile UI yet:
+- renaming a list
+- deleting a list
+- removing list members


### PR DESCRIPTION
## What changed
- Synchronized the root README with the current app state and fixed stale repository links.
- Updated the MVP plan to reflect what is already implemented in backend and mobile.
- Refreshed the feature READMEs for auth and lists so they describe the actual Flutter flow.

## Why
The docs had drifted from the implementation, which could mislead future work on the project.

## Impact
Future contributors now have an accurate view of:
- the implemented auth flow and session restore behavior
- the current list overview/detail screens
- sharing and item CRUD support
- the remaining MVP follow-up work

## Validation
- Documentation-only change
- Verified the updated text against the current backend and mobile code paths