### PR TITLE
Move checked shopping items to the bottom

### DIFF
--- a/mobile/lib/features/lists/list_detail_page.dart
+++ b/mobile/lib/features/lists/list_detail_page.dart
@@ -593,14 +593,7 @@ class _ListDetailPageState extends State<ListDetailPage> {
   }
 
   void _sortItems() {
-    _items.sort((left, right) {
-      final byOrder = left.sortOrder.compareTo(right.sortOrder);
-      if (byOrder != 0) {
-        return byOrder;
-      }
-
-      return left.createdAt.compareTo(right.createdAt);
-    });
+    _items.sort(_compareItems);
   }
 
   List<ShoppingListItem> _mergeFetchedItems(
@@ -639,16 +632,27 @@ class _ListDetailPageState extends State<ListDetailPage> {
       }
     }
 
-    merged.sort((left, right) {
-      final byOrder = left.sortOrder.compareTo(right.sortOrder);
-      if (byOrder != 0) {
-        return byOrder;
-      }
-
-      return left.createdAt.compareTo(right.createdAt);
-    });
+    merged.sort(_compareItems);
 
     return merged;
+  }
+
+  int _compareItems(ShoppingListItem left, ShoppingListItem right) {
+    final byChecked = left.isChecked == right.isChecked
+        ? 0
+        : left.isChecked
+            ? 1
+            : -1;
+    if (byChecked != 0) {
+      return byChecked;
+    }
+
+    final byOrder = left.sortOrder.compareTo(right.sortOrder);
+    if (byOrder != 0) {
+      return byOrder;
+    }
+
+    return left.createdAt.compareTo(right.createdAt);
   }
 
   int _nextSortOrder() {

--- a/mobile/test/list_detail_page_test.dart
+++ b/mobile/test/list_detail_page_test.dart
@@ -175,6 +175,52 @@ void main() {
 
     expect(await resultCompleter.future, true);
   });
+
+  testWidgets('moves checked items below unchecked items',
+      (tester) async {
+    final updateCompleter = Completer<ShoppingListItem>();
+    final apiClient = _FakeApiClient(
+      items: <ShoppingListItem>[
+        _item(
+          id: 'item_1',
+          name: 'Milk',
+          sortOrder: 0,
+        ),
+        _item(
+          id: 'item_2',
+          name: 'Bread',
+          sortOrder: 1,
+        ),
+      ],
+      updateItemHandler: (_, __, ___) => updateCompleter.future,
+    );
+
+    await tester.pumpWidget(buildSubject(apiClient));
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.getTopLeft(find.text('Milk')).dy,
+      lessThan(tester.getTopLeft(find.text('Bread')).dy),
+    );
+
+    await tester.tap(find.byType(Checkbox).first);
+    await tester.pump();
+
+    expect(
+      tester.getTopLeft(find.text('Bread')).dy,
+      lessThan(tester.getTopLeft(find.text('Milk')).dy),
+    );
+
+    updateCompleter.complete(
+      _item(
+        id: 'item_1',
+        name: 'Milk',
+        sortOrder: 0,
+        isChecked: true,
+      ),
+    );
+    await tester.pumpAndSettle();
+  });
 }
 
 final ShoppingListItem _milkItem = _item(


### PR DESCRIPTION
Checked items now sort below unchecked items in the list detail view, while keeping the existing sort order and refresh behavior intact.

Tests:
- `flutter test test/list_detail_page_test.dart test/api_client_test.dart`