### PR TITLE
[codex] list rename flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ W kodzie są już dostępne:
 - widok list i widok szczegółów listy
 - tworzenie list
 - współdzielenie list z innym użytkownikiem
+- zmiana nazwy listy z widoku szczegółów przez właściciela
 - dodawanie, edycja, usuwanie i odhaczanie pozycji
 - odświeżanie danych po zapisie oraz okresowy refresh w widoku szczegółów listy
 

--- a/docs/mvp-plan.md
+++ b/docs/mvp-plan.md
@@ -55,6 +55,7 @@ Implemented in the current codebase:
 - mobile auth foundation with session persistence and session restore on launch
 - list overview and detail flow on mobile
 - list sharing by email from the mobile UI
+- list renaming from the detail screen for owners
 - item create, edit, delete, and check-off actions on mobile
 - refresh-based sync after writes
 - periodic background refresh in the item detail view

--- a/mobile/lib/core/network/api_client.dart
+++ b/mobile/lib/core/network/api_client.dart
@@ -96,6 +96,20 @@ class ApiClient {
     });
   }
 
+  Future<ShoppingListSummary> updateList(String listId, String name) {
+    return _guard(() async {
+      final response = await _dio.patch<Map<String, dynamic>>(
+        '/lists/$listId',
+        data: {
+          'name': name.trim(),
+        },
+        options: _authOptions(),
+      );
+
+      return ShoppingListSummary.fromJson(_readObject(response.data, 'list'));
+    });
+  }
+
   Future<ShoppingListSummary> createList(String name) {
     return _guard(() async {
       final response = await _dio.post<Map<String, dynamic>>(

--- a/mobile/lib/features/auth/app_home_page.dart
+++ b/mobile/lib/features/auth/app_home_page.dart
@@ -167,6 +167,7 @@ class _AppHomePageState extends State<AppHomePage> {
           apiClient: _apiClient,
           listId: list.id,
           listName: list.name,
+          canManageList: list.ownerUserId == widget.session.session.user.id,
           onUnauthorized: widget.onLogout,
         ),
       ),
@@ -286,7 +287,8 @@ class _AppHomePageState extends State<AppHomePage> {
                     const SizedBox(height: 4),
                     Text(widget.session.session.user.email),
                     const SizedBox(height: 12),
-                    Text(widget.session.baseUrl, style: theme.textTheme.bodySmall),
+                    Text(widget.session.baseUrl,
+                        style: theme.textTheme.bodySmall),
                     const SizedBox(height: 8),
                     Wrap(
                       spacing: 8,
@@ -331,7 +333,8 @@ class _AppHomePageState extends State<AppHomePage> {
               const Padding(
                 padding: EdgeInsets.only(top: 32),
                 child: Center(
-                  child: Text('No lists yet. Create the first one to get started.'),
+                  child: Text(
+                      'No lists yet. Create the first one to get started.'),
                 ),
               )
             else

--- a/mobile/lib/features/lists/README.md
+++ b/mobile/lib/features/lists/README.md
@@ -5,10 +5,10 @@ Current mobile flow:
 - create-list action from the authenticated home screen
 - list detail page with item list, add, edit, delete, and check-off actions
 - share-list action by email from the detail screen
+- rename-list action from the detail screen for list owners
 - optimistic updates with reconciliation after server writes
 - periodic refresh in the detail view to catch changes from the other user
 
 Backend capabilities that already exist but are not fully exposed in the mobile UI yet:
-- renaming a list
 - deleting a list
 - removing list members

--- a/mobile/lib/features/lists/list_detail_page.dart
+++ b/mobile/lib/features/lists/list_detail_page.dart
@@ -10,6 +10,7 @@ class ListDetailPage extends StatefulWidget {
     required this.apiClient,
     required this.listId,
     this.listName,
+    this.canManageList = false,
     this.onUnauthorized,
     super.key,
   });
@@ -17,6 +18,7 @@ class ListDetailPage extends StatefulWidget {
   final ApiClient apiClient;
   final String listId;
   final String? listName;
+  final bool canManageList;
   final Future<void> Function()? onUnauthorized;
 
   @override
@@ -29,9 +31,10 @@ class _ListDetailPageState extends State<ListDetailPage> {
   final Map<String, _PendingItemMutation> _pendingItemMutations =
       <String, _PendingItemMutation>{};
 
+  late String _listName;
   bool _isLoading = true;
   bool _isSharing = false;
-  bool _didMutateItems = false;
+  bool _didMutateList = false;
   String? _errorMessage;
   int _temporaryItemCounter = 0;
   Timer? _refreshTimer;
@@ -39,6 +42,7 @@ class _ListDetailPageState extends State<ListDetailPage> {
   @override
   void initState() {
     super.initState();
+    _listName = widget.listName ?? 'List ${widget.listId}';
     _reloadItems();
     _refreshTimer = Timer.periodic(const Duration(seconds: 15), (_) {
       if (mounted) {
@@ -124,7 +128,7 @@ class _ListDetailPageState extends State<ListDetailPage> {
     );
 
     setState(() {
-      _didMutateItems = true;
+      _didMutateList = true;
       _pendingItemIds.add(temporaryId);
       _pendingItemMutations[temporaryId] = _PendingItemMutation.create(
         optimisticItem: optimisticItem,
@@ -198,7 +202,7 @@ class _ListDetailPageState extends State<ListDetailPage> {
     );
 
     setState(() {
-      _didMutateItems = true;
+      _didMutateList = true;
       _pendingItemIds.add(item.id);
       _pendingItemMutations[item.id] = _PendingItemMutation.update(
         previousItem: previousItem,
@@ -267,12 +271,12 @@ class _ListDetailPageState extends State<ListDetailPage> {
     }
 
     final optimisticItem = _items[existingIndex].toDraft().copyWith(
-      isChecked: checked,
-    );
+          isChecked: checked,
+        );
     final previousItem = _items[existingIndex];
 
     setState(() {
-      _didMutateItems = true;
+      _didMutateList = true;
       _pendingItemIds.add(item.id);
       _pendingItemMutations[item.id] = _PendingItemMutation.update(
         previousItem: previousItem,
@@ -363,7 +367,7 @@ class _ListDetailPageState extends State<ListDetailPage> {
     final previousItem = _items[existingIndex];
 
     setState(() {
-      _didMutateItems = true;
+      _didMutateList = true;
       _pendingItemIds.add(item.id);
       _pendingItemMutations[item.id] = _PendingItemMutation.delete(
         previousItem: previousItem,
@@ -461,9 +465,63 @@ class _ListDetailPageState extends State<ListDetailPage> {
     }
   }
 
+  Future<void> _renameList() async {
+    if (!widget.canManageList) {
+      return;
+    }
+
+    final nextName = await showDialog<String>(
+      context: context,
+      builder: (context) {
+        return _ListNameDialog(
+          title: 'Rename list',
+          initialValue: _listName,
+          actionLabel: 'Save',
+        );
+      },
+    );
+
+    if (nextName == null || nextName == _listName) {
+      return;
+    }
+
+    try {
+      final updatedList = await widget.apiClient.updateList(
+        widget.listId,
+        nextName,
+      );
+
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _didMutateList = true;
+        _listName = updatedList.name;
+      });
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Renamed to ${updatedList.name}.')),
+      );
+    } on ApiException catch (error) {
+      if (error.isUnauthorized && widget.onUnauthorized != null) {
+        await widget.onUnauthorized!();
+        return;
+      }
+
+      if (!mounted) {
+        return;
+      }
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Could not rename list: ${error.message}')),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    final title = widget.listName ?? 'List ${widget.listId}';
+    final title = _listName;
 
     return PopScope<bool>(
       canPop: false,
@@ -472,12 +530,12 @@ class _ListDetailPageState extends State<ListDetailPage> {
           return;
         }
 
-        Navigator.of(context).pop(_didMutateItems);
+        Navigator.of(context).pop(_didMutateList);
       },
       child: Scaffold(
         appBar: AppBar(
           leading: BackButton(
-            onPressed: () => Navigator.of(context).pop(_didMutateItems),
+            onPressed: () => Navigator.of(context).pop(_didMutateList),
           ),
           title: Text(title),
           bottom: widget.listName == null
@@ -501,6 +559,8 @@ class _ListDetailPageState extends State<ListDetailPage> {
               onSelected: (action) {
                 if (action == _ListAction.share) {
                   _shareList();
+                } else if (action == _ListAction.rename) {
+                  _renameList();
                 }
               },
               itemBuilder: (context) => [
@@ -509,6 +569,11 @@ class _ListDetailPageState extends State<ListDetailPage> {
                   enabled: !_isSharing,
                   child: const Text('Share list'),
                 ),
+                if (widget.canManageList)
+                  const PopupMenuItem<_ListAction>(
+                    value: _ListAction.rename,
+                    child: Text('Rename list'),
+                  ),
               ],
             ),
           ],
@@ -560,9 +625,8 @@ class _ListDetailPageState extends State<ListDetailPage> {
       child: ListTile(
         leading: Checkbox(
           value: item.isChecked,
-          onChanged: isPending
-              ? null
-              : (checked) => _onToggleRequested(item, checked),
+          onChanged:
+              isPending ? null : (checked) => _onToggleRequested(item, checked),
         ),
         title: Text(
           item.name,
@@ -772,7 +836,7 @@ class _ListDetailPageState extends State<ListDetailPage> {
   }
 }
 
-enum _ListAction { share }
+enum _ListAction { share, rename }
 
 enum _PendingItemMutationType { create, update, delete }
 
@@ -1013,6 +1077,87 @@ class _ShareListDialogState extends State<_ShareListDialog> {
           child: const Text('Cancel'),
         ),
         FilledButton(onPressed: _submit, child: const Text('Share')),
+      ],
+    );
+  }
+}
+
+class _ListNameDialog extends StatefulWidget {
+  const _ListNameDialog({
+    required this.title,
+    required this.initialValue,
+    required this.actionLabel,
+  });
+
+  final String title;
+  final String initialValue;
+  final String actionLabel;
+
+  @override
+  State<_ListNameDialog> createState() => _ListNameDialogState();
+}
+
+class _ListNameDialogState extends State<_ListNameDialog> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialValue);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    if (!(_formKey.currentState?.validate() ?? false)) {
+      return;
+    }
+
+    Navigator.of(context).pop(_controller.text.trim());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(widget.title),
+      content: Form(
+        key: _formKey,
+        child: TextFormField(
+          controller: _controller,
+          autofocus: true,
+          decoration: const InputDecoration(labelText: 'List name'),
+          maxLength: 100,
+          textInputAction: TextInputAction.done,
+          onFieldSubmitted: (_) => _submit(),
+          validator: (value) {
+            final trimmed = value?.trim() ?? '';
+
+            if (trimmed.isEmpty) {
+              return 'List name is required';
+            }
+
+            if (trimmed.length > 100) {
+              return 'List name must be at most 100 characters';
+            }
+
+            return null;
+          },
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _submit,
+          child: Text(widget.actionLabel),
+        ),
       ],
     );
   }

--- a/mobile/test/api_client_test.dart
+++ b/mobile/test/api_client_test.dart
@@ -90,7 +90,8 @@ void main() {
     expect(item.createdByUserId, 'user_1');
   });
 
-  test('ShoppingListItem.toDraft and ItemDraft.toJson preserve nullable fields', () {
+  test('ShoppingListItem.toDraft and ItemDraft.toJson preserve nullable fields',
+      () {
     final item = ShoppingListItem(
       id: 'item_1',
       listId: 'list_1',
@@ -166,7 +167,8 @@ void main() {
     expect(memberException.statusCode, 409);
   });
 
-  test('ApiClient login sends credentials and parses the auth session', () async {
+  test('ApiClient login sends credentials and parses the auth session',
+      () async {
     final adapter = _RecordingAdapter(
       ResponseBody.fromString(
         jsonEncode({
@@ -206,6 +208,43 @@ void main() {
     expect(adapter.lastRequest?.headers['Authorization'], isNull);
     expect(session.accessToken, 'jwt-token');
     expect(session.user.email, 'test@example.com');
+  });
+
+  test('ApiClient updateList sends the new list name and parses the response',
+      () async {
+    final adapter = _RecordingAdapter(
+      ResponseBody.fromString(
+        jsonEncode({
+          'list': {
+            'id': 'list_1',
+            'name': 'Weekend groceries',
+            'ownerUserId': 'user_1',
+            'createdAt': '2026-03-30T10:00:00.000Z',
+            'updatedAt': '2026-03-31T10:00:00.000Z',
+          },
+        }),
+        200,
+        headers: {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+        },
+      ),
+    );
+    final dio = Dio();
+    dio.httpClientAdapter = adapter;
+
+    final client = ApiClient(
+      baseUrl: 'http://localhost:3000/',
+      accessToken: 'token',
+      dio: dio,
+    );
+    final list = await client.updateList('list_1', 'Weekend groceries');
+
+    expect(adapter.lastRequest?.path, '/lists/list_1');
+    expect(adapter.lastRequest?.method, 'PATCH');
+    expect(adapter.lastRequest?.data, {'name': 'Weekend groceries'});
+    expect(adapter.lastRequest?.headers['Authorization'], 'Bearer token');
+    expect(list.name, 'Weekend groceries');
+    expect(list.ownerUserId, 'user_1');
   });
 
   test('AuthSession and AuthUser parse API payloads', () {

--- a/mobile/test/list_detail_page_test.dart
+++ b/mobile/test/list_detail_page_test.dart
@@ -6,12 +6,16 @@ import 'package:zakupy_mobile/core/network/api_client.dart';
 import 'package:zakupy_mobile/features/lists/list_detail_page.dart';
 
 void main() {
-  Widget buildSubject(_FakeApiClient apiClient) {
+  Widget buildSubject(
+    _FakeApiClient apiClient, {
+    bool canManageList = false,
+  }) {
     return MaterialApp(
       home: ListDetailPage(
         apiClient: apiClient,
         listId: 'list_1',
         listName: 'Weekly groceries',
+        canManageList: canManageList,
       ),
     );
   }
@@ -74,7 +78,7 @@ void main() {
     await tester.pumpWidget(buildSubject(apiClient));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byType(PopupMenuButton));
+    await tester.tap(find.byIcon(Icons.more_vert));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Share list'));
     await tester.pumpAndSettle();
@@ -87,6 +91,61 @@ void main() {
 
     expect(apiClient.shareListCalls, 1);
     expect(find.text('Shared with second-user@example.com.'), findsOneWidget);
+  });
+
+  testWidgets('renames a list and refreshes the title', (tester) async {
+    final apiClient = _FakeApiClient(
+      items: <ShoppingListItem>[_milkItem],
+      updateListHandler: (_, name) async {
+        return ShoppingListSummary(
+          id: 'list_1',
+          name: name,
+          ownerUserId: 'user_1',
+          createdAt: DateTime.utc(2026, 3, 31, 8),
+          updatedAt: DateTime.utc(2026, 4, 1, 12),
+        );
+      },
+    );
+
+    await tester.pumpWidget(buildSubject(apiClient, canManageList: true));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Rename list'));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'List name'),
+      'Weekend groceries',
+    );
+    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    expect(apiClient.updateListCalls, 1);
+    expect(find.text('Weekend groceries'), findsWidgets);
+    expect(find.text('Renamed to Weekend groceries.'), findsOneWidget);
+  });
+
+  testWidgets('rejects an empty rename before calling the backend', (
+    tester,
+  ) async {
+    final apiClient = _FakeApiClient(
+      items: <ShoppingListItem>[_milkItem],
+    );
+
+    await tester.pumpWidget(buildSubject(apiClient, canManageList: true));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Rename list'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.widgetWithText(TextFormField, 'List name'), '');
+    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    await tester.pump();
+
+    expect(find.text('List name is required'), findsOneWidget);
+    expect(apiClient.updateListCalls, 0);
   });
 
   testWidgets('reverts an optimistic edit when the backend rejects it', (
@@ -235,8 +294,7 @@ void main() {
     expect(await resultCompleter.future, true);
   });
 
-  testWidgets('moves checked items below unchecked items',
-      (tester) async {
+  testWidgets('moves checked items below unchecked items', (tester) async {
     final updateCompleter = Completer<ShoppingListItem>();
     final apiClient = _FakeApiClient(
       items: <ShoppingListItem>[
@@ -317,6 +375,7 @@ class _FakeApiClient extends ApiClient {
     required this.items,
     this.createItemHandler,
     this.updateItemHandler,
+    this.updateListHandler,
     this.deleteItemHandler,
     this.fetchItemsHandler,
     this.shareListHandler,
@@ -324,22 +383,24 @@ class _FakeApiClient extends ApiClient {
 
   final List<ShoppingListItem> items;
   final Future<List<ShoppingListItem>> Function(int callCount)?
-  fetchItemsHandler;
+      fetchItemsHandler;
   final Future<ShoppingListItem> Function(String listId, ItemDraft draft)?
-  createItemHandler;
+      createItemHandler;
   final Future<ShoppingListItem> Function(
     String listId,
     String itemId,
     ItemDraft draft,
-  )?
-  updateItemHandler;
+  )? updateItemHandler;
+  final Future<ShoppingListSummary> Function(String listId, String name)?
+      updateListHandler;
   final Future<void> Function(String listId, String itemId)? deleteItemHandler;
   final Future<ListMember> Function(String listId, String email)?
-  shareListHandler;
+      shareListHandler;
 
   int createItemCalls = 0;
   int fetchItemsCalls = 0;
   int shareListCalls = 0;
+  int updateListCalls = 0;
 
   @override
   Future<List<ShoppingListItem>> fetchItems(String listId) async {
@@ -392,6 +453,23 @@ class _FakeApiClient extends ApiClient {
     );
     items[index] = updatedItem;
     return updatedItem;
+  }
+
+  @override
+  Future<ShoppingListSummary> updateList(String listId, String name) async {
+    updateListCalls += 1;
+
+    if (updateListHandler != null) {
+      return updateListHandler!(listId, name);
+    }
+
+    return ShoppingListSummary(
+      id: listId,
+      name: name,
+      ownerUserId: 'user_1',
+      createdAt: DateTime.utc(2026, 3, 31, 8),
+      updatedAt: DateTime.utc(2026, 4, 1, 12),
+    );
   }
 
   @override


### PR DESCRIPTION
## What changed
- Added a `PATCH /lists/:listId` client method so the mobile app can rename lists through the existing backend API.
- Exposed a rename action in the list detail screen for list owners only.
- Added an inline rename dialog with validation and success/error feedback.
- Passed list ownership into the detail screen from the authenticated home flow so only owners see the rename action.
- Updated docs to reflect the newly exposed mobile capability.

## Why
The backend already supported list renaming, but the mobile UI did not expose it. This PR closes that gap so owners can manage list names directly from the app.

## Validation
- `flutter test test/api_client_test.dart test/list_detail_page_test.dart`
- `flutter test`

## Notes
- Empty rename submissions are rejected before making a network call.
- Non-owners do not see the rename action.