### PR TITLE
[codex] manual theme switch

### DIFF
--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -6,26 +6,68 @@ import 'features/auth/auth_repository.dart';
 import 'features/auth/auth_session_store.dart';
 import 'features/auth/session_controller.dart';
 
-const _defaultApiBaseUrl = String.fromEnvironment('API_BASE_URL', defaultValue: '');
+const _defaultApiBaseUrl =
+    String.fromEnvironment('API_BASE_URL', defaultValue: '');
 
-class ZakupyApp extends StatelessWidget {
+ThemeData buildLightTheme() {
+  return ThemeData(
+    colorScheme: ColorScheme.fromSeed(
+      seedColor: const Color(0xFF2F6B3B),
+      brightness: Brightness.light,
+    ),
+    useMaterial3: true,
+  );
+}
+
+ThemeData buildDarkTheme() {
+  return ThemeData(
+    colorScheme: ColorScheme.fromSeed(
+      seedColor: const Color(0xFF2F6B3B),
+      brightness: Brightness.dark,
+    ),
+    useMaterial3: true,
+  );
+}
+
+class ZakupyApp extends StatefulWidget {
   const ZakupyApp({super.key});
+
+  @override
+  State<ZakupyApp> createState() => _ZakupyAppState();
+}
+
+class _ZakupyAppState extends State<ZakupyApp> {
+  ThemeMode _themeMode = ThemeMode.system;
+
+  void _setThemeMode(ThemeMode themeMode) {
+    setState(() {
+      _themeMode = themeMode;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Zakupy',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF2F6B3B)),
-        useMaterial3: true,
+      theme: buildLightTheme(),
+      darkTheme: buildDarkTheme(),
+      themeMode: _themeMode,
+      home: _AppBootstrapper(
+        themeMode: _themeMode,
+        onThemeModeChanged: _setThemeMode,
       ),
-      home: const _AppBootstrapper(),
     );
   }
 }
 
 class _AppBootstrapper extends StatefulWidget {
-  const _AppBootstrapper();
+  const _AppBootstrapper({
+    required this.themeMode,
+    required this.onThemeModeChanged,
+  });
+
+  final ThemeMode themeMode;
+  final ValueChanged<ThemeMode> onThemeModeChanged;
 
   @override
   State<_AppBootstrapper> createState() => _AppBootstrapperState();
@@ -78,6 +120,8 @@ class _AppBootstrapperState extends State<_AppBootstrapper> {
             session: state.session!,
             authRepository: _authRepository,
             onLogout: _sessionController.logout,
+            themeMode: widget.themeMode,
+            onThemeModeChanged: widget.onThemeModeChanged,
           );
         }
 
@@ -85,6 +129,8 @@ class _AppBootstrapperState extends State<_AppBootstrapper> {
           initialBaseUrl: _defaultApiBaseUrl,
           isSubmitting: state.status == SessionStatus.loading,
           errorMessage: state.errorMessage,
+          themeMode: widget.themeMode,
+          onThemeModeChanged: widget.onThemeModeChanged,
           onLogin: ({
             required String baseUrl,
             required String email,

--- a/mobile/lib/core/theme/theme_mode_menu.dart
+++ b/mobile/lib/core/theme/theme_mode_menu.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+class ThemeModeMenuButton extends StatelessWidget {
+  const ThemeModeMenuButton({
+    required this.currentThemeMode,
+    required this.onSelected,
+    super.key,
+  });
+
+  final ThemeMode currentThemeMode;
+  final ValueChanged<ThemeMode> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton<ThemeMode>(
+      tooltip: 'Appearance',
+      onSelected: onSelected,
+      icon: const Icon(Icons.brightness_6_outlined),
+      itemBuilder: (context) => [
+        PopupMenuItem<ThemeMode>(
+          value: ThemeMode.system,
+          child: _MenuItem(
+            label: 'System',
+            selected: currentThemeMode == ThemeMode.system,
+          ),
+        ),
+        PopupMenuItem<ThemeMode>(
+          value: ThemeMode.light,
+          child: _MenuItem(
+            label: 'Light',
+            selected: currentThemeMode == ThemeMode.light,
+          ),
+        ),
+        PopupMenuItem<ThemeMode>(
+          value: ThemeMode.dark,
+          child: _MenuItem(
+            label: 'Dark',
+            selected: currentThemeMode == ThemeMode.dark,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _MenuItem extends StatelessWidget {
+  const _MenuItem({
+    required this.label,
+    required this.selected,
+  });
+
+  final String label;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (selected) const Icon(Icons.check, size: 18),
+        if (selected) const SizedBox(width: 8),
+        Text(label),
+      ],
+    );
+  }
+}

--- a/mobile/lib/features/auth/app_home_page.dart
+++ b/mobile/lib/features/auth/app_home_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../core/network/api_client.dart';
 import '../../core/network/collection_sync.dart';
+import '../../core/theme/theme_mode_menu.dart';
 import '../lists/list_detail_page.dart';
 import 'auth_repository.dart';
 import 'auth_session_store.dart';
@@ -11,12 +12,16 @@ class AppHomePage extends StatefulWidget {
     required this.session,
     required this.authRepository,
     required this.onLogout,
+    required this.themeMode,
+    required this.onThemeModeChanged,
     super.key,
   });
 
   final StoredAuthSession session;
   final AuthRepository authRepository;
   final Future<void> Function() onLogout;
+  final ThemeMode themeMode;
+  final ValueChanged<ThemeMode> onThemeModeChanged;
 
   @override
   State<AppHomePage> createState() => _AppHomePageState();
@@ -241,6 +246,10 @@ class _AppHomePageState extends State<AppHomePage> {
           IconButton(
             onPressed: _isUpdating ? null : () => _loadLists(),
             icon: const Icon(Icons.refresh),
+          ),
+          ThemeModeMenuButton(
+            currentThemeMode: widget.themeMode,
+            onSelected: widget.onThemeModeChanged,
           ),
           PopupMenuButton<String>(
             onSelected: (value) async {

--- a/mobile/lib/features/auth/auth_page.dart
+++ b/mobile/lib/features/auth/auth_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../../core/theme/theme_mode_menu.dart';
+
 typedef LoginSubmit = Future<void> Function(
     {required String baseUrl, required String email, required String password});
 
@@ -13,6 +15,8 @@ class AuthPage extends StatefulWidget {
   const AuthPage(
       {required this.onLogin,
       required this.onRegister,
+      required this.themeMode,
+      required this.onThemeModeChanged,
       this.initialBaseUrl = '',
       this.isSubmitting = false,
       this.errorMessage,
@@ -20,6 +24,8 @@ class AuthPage extends StatefulWidget {
 
   final LoginSubmit onLogin;
   final RegisterSubmit onRegister;
+  final ThemeMode themeMode;
+  final ValueChanged<ThemeMode> onThemeModeChanged;
   final String initialBaseUrl;
   final bool isSubmitting;
   final String? errorMessage;
@@ -81,6 +87,15 @@ class _AuthPageState extends State<AuthPage> {
     final theme = Theme.of(context);
 
     return Scaffold(
+        appBar: AppBar(
+          title: const Text('Zakupy'),
+          actions: [
+            ThemeModeMenuButton(
+              currentThemeMode: widget.themeMode,
+              onSelected: widget.onThemeModeChanged,
+            ),
+          ],
+        ),
         body: Container(
             decoration: BoxDecoration(
                 gradient: LinearGradient(
@@ -91,6 +106,7 @@ class _AuthPageState extends State<AuthPage> {
                   theme.colorScheme.surface
                 ])),
             child: SafeArea(
+                top: false,
                 child: Center(
                     child: SingleChildScrollView(
                         padding: const EdgeInsets.all(24),

--- a/mobile/test/app_theme_test.dart
+++ b/mobile/test/app_theme_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zakupy_mobile/app.dart';
+import 'package:zakupy_mobile/core/theme/theme_mode_menu.dart';
+
+void main() {
+  test('buildDarkTheme uses a dark color scheme', () {
+    final theme = buildDarkTheme();
+
+    expect(theme.brightness, Brightness.dark);
+    expect(theme.colorScheme.brightness, Brightness.dark);
+    expect(theme.useMaterial3, true);
+  });
+
+  test('buildLightTheme uses a light color scheme', () {
+    final theme = buildLightTheme();
+
+    expect(theme.brightness, Brightness.light);
+    expect(theme.colorScheme.brightness, Brightness.light);
+    expect(theme.useMaterial3, true);
+  });
+
+  testWidgets('theme mode menu selects dark mode', (tester) async {
+    var currentThemeMode = ThemeMode.system;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(
+            actions: [
+              ThemeModeMenuButton(
+                currentThemeMode: currentThemeMode,
+                onSelected: (themeMode) {
+                  currentThemeMode = themeMode;
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byIcon(Icons.brightness_6_outlined));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Dark'));
+    await tester.pumpAndSettle();
+
+    expect(currentThemeMode, ThemeMode.dark);
+  });
+}


### PR DESCRIPTION
## What changed
- Added an in-app appearance menu so the user can switch between System, Light, and Dark mode.
- Wired the selected theme mode through the app shell so both the login screen and the authenticated home screen respond immediately.
- Added a shared menu widget and a widget test covering the dark-mode selection path.

## Why
The app now supports system dark mode, but the simulator/user still needs a manual override when they want to force the black theme inside the app.

## Validation
- `flutter test test/app_theme_test.dart`
- `flutter test`

## Notes
- The manual selection is session-scoped for now; it does not persist after restart.
- The existing system theme behavior remains the default.