### PR TITLE
Fix mobile no-body requests for delete and archive flows

### DIFF
--- a/mobile/lib/core/network/api_client.dart
+++ b/mobile/lib/core/network/api_client.dart
@@ -92,7 +92,7 @@ class ApiClient {
     return _guard(() async {
       final response = await _dio.post<Map<String, dynamic>>(
         '/auth/logout',
-        options: _authOptions(),
+        options: _authOptionsWithoutBody(),
       );
 
       final status = _readString(response.data, 'status');
@@ -153,7 +153,7 @@ class ApiClient {
     return _guard(() async {
       final response = await _dio.post<Map<String, dynamic>>(
         '/lists/$listId/archive',
-        options: _authOptions(),
+        options: _authOptionsWithoutBody(),
       );
 
       return ShoppingListSummary.fromJson(_readObject(response.data, 'list'));
@@ -164,7 +164,7 @@ class ApiClient {
     return _guard(() async {
       final response = await _dio.post<Map<String, dynamic>>(
         '/lists/$listId/restore',
-        options: _authOptions(),
+        options: _authOptionsWithoutBody(),
       );
 
       return ShoppingListSummary.fromJson(_readObject(response.data, 'list'));
@@ -254,10 +254,7 @@ class ApiClient {
     return _guard(() async {
       await _dio.delete<void>(
         '/lists/$listId/items/$itemId',
-        options: Options(
-          headers: _authHeaders(),
-          contentType: null,
-        ),
+        options: _authOptionsWithoutBody(),
       );
     });
   }
@@ -280,6 +277,15 @@ class ApiClient {
     }
 
     return Options(headers: headers);
+  }
+
+  Options _authOptionsWithoutBody() {
+    final headers = _authHeaders();
+
+    return Options(
+      headers: headers.isEmpty ? null : headers,
+      contentType: null,
+    );
   }
 
   Future<T> _guard<T>(Future<T> Function() action) async {

--- a/mobile/test/api_client_test.dart
+++ b/mobile/test/api_client_test.dart
@@ -299,6 +299,84 @@ void main() {
     expect(adapter.lastRequest?.headers['Authorization'], 'Bearer session-token');
   });
 
+  test('ApiClient archiveList sends no json content type or body', () async {
+    final adapter = _RecordingAdapter(
+      ResponseBody.fromString(
+        jsonEncode({
+          'list': {
+            'id': 'list_1',
+            'name': 'Weekly groceries',
+            'ownerUserId': 'user_1',
+            'isArchived': true,
+            'archivedAt': '2026-04-11T12:00:00.000Z',
+            'createdAt': '2026-04-10T12:00:00.000Z',
+            'updatedAt': '2026-04-11T12:00:00.000Z',
+          },
+        }),
+        200,
+        headers: {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+        },
+      ),
+    );
+    final dio = Dio();
+    dio.httpClientAdapter = adapter;
+
+    final client = ApiClient(
+      baseUrl: 'http://localhost:3000/',
+      accessToken: 'session-token',
+      dio: dio,
+    );
+
+    final result = await client.archiveList('list_1');
+
+    expect(adapter.lastRequest?.path, '/lists/list_1/archive');
+    expect(adapter.lastRequest?.method, 'POST');
+    expect(adapter.lastRequest?.data, isNull);
+    expect(adapter.lastRequest?.contentType, isNull);
+    expect(adapter.lastRequest?.headers['Authorization'], 'Bearer session-token');
+    expect(result.isArchived, true);
+  });
+
+  test('ApiClient restoreList sends no json content type or body', () async {
+    final adapter = _RecordingAdapter(
+      ResponseBody.fromString(
+        jsonEncode({
+          'list': {
+            'id': 'list_1',
+            'name': 'Weekly groceries',
+            'ownerUserId': 'user_1',
+            'isArchived': false,
+            'archivedAt': null,
+            'createdAt': '2026-04-10T12:00:00.000Z',
+            'updatedAt': '2026-04-11T12:00:00.000Z',
+          },
+        }),
+        200,
+        headers: {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+        },
+      ),
+    );
+    final dio = Dio();
+    dio.httpClientAdapter = adapter;
+
+    final client = ApiClient(
+      baseUrl: 'http://localhost:3000/',
+      accessToken: 'session-token',
+      dio: dio,
+    );
+
+    final result = await client.restoreList('list_1');
+
+    expect(adapter.lastRequest?.path, '/lists/list_1/restore');
+    expect(adapter.lastRequest?.method, 'POST');
+    expect(adapter.lastRequest?.data, isNull);
+    expect(adapter.lastRequest?.contentType, isNull);
+    expect(adapter.lastRequest?.headers['Authorization'], 'Bearer session-token');
+    expect(result.isArchived, false);
+  });
+
   test('ApiClient shareList parses a pending invitation response', () async {
     final adapter = _RecordingAdapter(
       ResponseBody.fromString(


### PR DESCRIPTION
Summary

- fixes authenticated requests that do not send a body so they no longer inherit `application/json`
- covers delete-item, archive-list, restore-list, and logout
- adds API client regression tests for archive and restore requests

Testing

- `flutter test test/api_client_test.dart test/list_detail_page_test.dart test/archived_lists_page_test.dart --reporter compact`
- `flutter analyze lib/core/network/api_client.dart test/api_client_test.dart test/list_detail_page_test.dart test/archived_lists_page_test.dart`

Why

- the app was still sending body-less authenticated requests with JSON content type, which triggered backend errors like:
  - `Body cannot be empty when content-type is set to application/json`
- the same root cause affected item deletion and list archive/restore