### PR TITLE
Fix Dio base content type for body-less mobile requests

### DIFF
--- a/mobile/lib/core/network/api_client.dart
+++ b/mobile/lib/core/network/api_client.dart
@@ -19,7 +19,6 @@ class ApiClient {
             Dio(
               BaseOptions(
                 baseUrl: normalizeBaseUrl(baseUrl),
-                contentType: Headers.jsonContentType,
                 responseType: ResponseType.json,
               ),
             );
@@ -92,7 +91,7 @@ class ApiClient {
     return _guard(() async {
       final response = await _dio.post<Map<String, dynamic>>(
         '/auth/logout',
-        options: _authOptionsWithoutBody(),
+        options: _authOptions(),
       );
 
       final status = _readString(response.data, 'status');
@@ -153,7 +152,7 @@ class ApiClient {
     return _guard(() async {
       final response = await _dio.post<Map<String, dynamic>>(
         '/lists/$listId/archive',
-        options: _authOptionsWithoutBody(),
+        options: _authOptions(),
       );
 
       return ShoppingListSummary.fromJson(_readObject(response.data, 'list'));
@@ -164,7 +163,7 @@ class ApiClient {
     return _guard(() async {
       final response = await _dio.post<Map<String, dynamic>>(
         '/lists/$listId/restore',
-        options: _authOptionsWithoutBody(),
+        options: _authOptions(),
       );
 
       return ShoppingListSummary.fromJson(_readObject(response.data, 'list'));
@@ -254,7 +253,7 @@ class ApiClient {
     return _guard(() async {
       await _dio.delete<void>(
         '/lists/$listId/items/$itemId',
-        options: _authOptionsWithoutBody(),
+        options: _authOptions(),
       );
     });
   }
@@ -277,15 +276,6 @@ class ApiClient {
     }
 
     return Options(headers: headers);
-  }
-
-  Options _authOptionsWithoutBody() {
-    final headers = _authHeaders();
-
-    return Options(
-      headers: headers.isEmpty ? null : headers,
-      contentType: null,
-    );
   }
 
   Future<T> _guard<T>(Future<T> Function() action) async {

--- a/mobile/test/api_client_test.dart
+++ b/mobile/test/api_client_test.dart
@@ -272,6 +272,9 @@ void main() {
 
     expect(adapter.lastRequest?.path, '/auth/logout');
     expect(adapter.lastRequest?.method, 'POST');
+    expect(adapter.lastRequest?.data, isNull);
+    expect(adapter.lastRequest?.contentType, isNull);
+    expect(adapter.lastRequest?.headers[Headers.contentTypeHeader], isNull);
     expect(adapter.lastRequest?.headers['Authorization'], 'Bearer session-token');
   });
 
@@ -296,6 +299,7 @@ void main() {
     expect(adapter.lastRequest?.method, 'DELETE');
     expect(adapter.lastRequest?.data, isNull);
     expect(adapter.lastRequest?.contentType, isNull);
+    expect(adapter.lastRequest?.headers[Headers.contentTypeHeader], isNull);
     expect(adapter.lastRequest?.headers['Authorization'], 'Bearer session-token');
   });
 
@@ -334,6 +338,7 @@ void main() {
     expect(adapter.lastRequest?.method, 'POST');
     expect(adapter.lastRequest?.data, isNull);
     expect(adapter.lastRequest?.contentType, isNull);
+    expect(adapter.lastRequest?.headers[Headers.contentTypeHeader], isNull);
     expect(adapter.lastRequest?.headers['Authorization'], 'Bearer session-token');
     expect(result.isArchived, true);
   });
@@ -373,6 +378,7 @@ void main() {
     expect(adapter.lastRequest?.method, 'POST');
     expect(adapter.lastRequest?.data, isNull);
     expect(adapter.lastRequest?.contentType, isNull);
+    expect(adapter.lastRequest?.headers[Headers.contentTypeHeader], isNull);
     expect(adapter.lastRequest?.headers['Authorization'], 'Bearer session-token');
     expect(result.isArchived, false);
   });


### PR DESCRIPTION
Summary

- removes the global Dio base content type so requests without a body stop inheriting application/json
- routes delete, archive, restore, and logout through the normal auth options because Dio now sets JSON only when there is actual body data
- strengthens the regression tests to assert both request body and outgoing content-type header

Context

- #54 was incomplete because Dio still inherited application/json from BaseOptions even when per-request contentType was null.
- This is why delete and archive still failed at runtime with: Body cannot be empty when content-type is set to application/json.

Testing

- `flutter test test/api_client_test.dart test/list_detail_page_test.dart test/archived_lists_page_test.dart --reporter compact`
- `flutter analyze lib/core/network/api_client.dart test/api_client_test.dart test/list_detail_page_test.dart test/archived_lists_page_test.dart`
