### PR TITLE
Simplify list items and add product suggestions

### DIFF
--- a/backend/prisma/migrations/20260411140000_item_suggestions_and_simple_items/migration.sql
+++ b/backend/prisma/migrations/20260411140000_item_suggestions_and_simple_items/migration.sql
@@ -1,0 +1,90 @@
+-- AlterTable
+ALTER TABLE "list_items" ADD COLUMN "comment" TEXT;
+
+UPDATE "list_items"
+SET "comment" = NULLIF(
+  TRIM(
+    CONCAT_WS(
+      ' ',
+      CASE
+        WHEN "quantity" ~ '^[0-9]+$' THEN NULL
+        ELSE "quantity"
+      END,
+      "unit"
+    )
+  ),
+  ''
+);
+
+ALTER TABLE "list_items" ADD COLUMN "quantity_int" INTEGER NOT NULL DEFAULT 1;
+
+UPDATE "list_items"
+SET "quantity_int" = CASE
+  WHEN "quantity" ~ '^[0-9]+$' AND CAST("quantity" AS INTEGER) > 0 THEN CAST("quantity" AS INTEGER)
+  ELSE 1
+END;
+
+ALTER TABLE "list_items" DROP COLUMN "quantity";
+ALTER TABLE "list_items" DROP COLUMN "unit";
+ALTER TABLE "list_items" RENAME COLUMN "quantity_int" TO "quantity";
+
+-- CreateTable
+CREATE TABLE "item_suggestions" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "normalized_name" TEXT NOT NULL,
+    "comment" TEXT,
+    "normalized_comment" TEXT NOT NULL DEFAULT '',
+    "usage_count" INTEGER NOT NULL DEFAULT 1,
+    "last_used_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "item_suggestions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "item_suggestions_user_id_normalized_name_normalized_comment_key"
+ON "item_suggestions"("user_id", "normalized_name", "normalized_comment");
+
+-- CreateIndex
+CREATE INDEX "item_suggestions_user_id_usage_count_last_used_at_idx"
+ON "item_suggestions"("user_id", "usage_count", "last_used_at");
+
+-- Backfill current items into suggestions
+INSERT INTO "item_suggestions" (
+  "id",
+  "user_id",
+  "name",
+  "normalized_name",
+  "comment",
+  "normalized_comment",
+  "usage_count",
+  "last_used_at",
+  "created_at",
+  "updated_at"
+)
+SELECT
+  md5(CONCAT("created_by_user_id", ':', LOWER(BTRIM("name")), ':', COALESCE(LOWER(BTRIM("comment")), ''))),
+  "created_by_user_id",
+  "name",
+  LOWER(BTRIM("name")),
+  "comment",
+  COALESCE(NULLIF(LOWER(BTRIM("comment")), ''), ''),
+  SUM(GREATEST("quantity", 1)),
+  MAX("updated_at"),
+  MIN("created_at"),
+  MAX("updated_at")
+FROM "list_items"
+GROUP BY
+  "created_by_user_id",
+  "name",
+  LOWER(BTRIM("name")),
+  "comment",
+  COALESCE(NULLIF(LOWER(BTRIM("comment")), ''), '');
+
+-- AddForeignKey
+ALTER TABLE "item_suggestions"
+ADD CONSTRAINT "item_suggestions_user_id_fkey"
+FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -17,6 +17,7 @@ model User {
   archivedLists     ShoppingList[]   @relation("archived_lists")
   memberships       ListMember[]
   createdItems      ListItem[]
+  itemSuggestions   ItemSuggestion[]
   authSessions      AuthSession[]
   claimedInvites    ListInvitation[] @relation("claimed_invitations")
   sentInvitations   ListInvitation[] @relation("sent_invitations")
@@ -109,8 +110,8 @@ model ListItem {
   id              String       @id @default(cuid())
   listId          String       @map("list_id")
   name            String
-  quantity        String?
-  unit            String?
+  quantity        Int          @default(1)
+  comment         String?
   isChecked       Boolean      @default(false) @map("is_checked")
   sortOrder       Int          @default(0) @map("sort_order")
   createdByUserId String       @map("created_by_user_id")
@@ -120,6 +121,24 @@ model ListItem {
   createdByUser   User         @relation(fields: [createdByUserId], references: [id])
 
   @@map("list_items")
+}
+
+model ItemSuggestion {
+  id                String   @id @default(cuid())
+  userId            String   @map("user_id")
+  name              String
+  normalizedName    String   @map("normalized_name")
+  comment           String?
+  normalizedComment String   @default("") @map("normalized_comment")
+  usageCount        Int      @default(1) @map("usage_count")
+  lastUsedAt        DateTime @default(now()) @map("last_used_at")
+  createdAt         DateTime @default(now()) @map("created_at")
+  updatedAt         DateTime @updatedAt @map("updated_at")
+  user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, normalizedName, normalizedComment])
+  @@index([userId, usageCount, lastUsedAt])
+  @@map("item_suggestions")
 }
 
 enum ListRole {

--- a/backend/src/modules/items/routes.test.ts
+++ b/backend/src/modules/items/routes.test.ts
@@ -28,8 +28,8 @@ type TestItem = {
   id: string;
   listId: string;
   name: string;
-  quantity: string | null;
-  unit: string | null;
+  quantity: number;
+  comment: string | null;
   isChecked: boolean;
   sortOrder: number;
   createdByUserId: string;
@@ -43,6 +43,19 @@ type TestSession = {
   tokenHash: string;
   expiresAt: Date;
   revokedAt: Date | null;
+  lastUsedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type TestSuggestion = {
+  id: string;
+  userId: string;
+  name: string;
+  normalizedName: string;
+  comment: string | null;
+  normalizedComment: string;
+  usageCount: number;
   lastUsedAt: Date;
   createdAt: Date;
   updatedAt: Date;
@@ -76,11 +89,27 @@ function buildItem(overrides: Partial<TestItem> = {}): TestItem {
     id: 'item_1',
     listId: 'list_1',
     name: 'Milk',
-    quantity: '2',
-    unit: 'l',
+    quantity: 2,
+    comment: '2%',
     isChecked: false,
     sortOrder: 0,
     createdByUserId: 'user_1',
+    createdAt: new Date('2026-03-29T10:00:00.000Z'),
+    updatedAt: new Date('2026-03-29T10:00:00.000Z'),
+    ...overrides
+  };
+}
+
+function buildSuggestion(overrides: Partial<TestSuggestion> = {}): TestSuggestion {
+  return {
+    id: 'suggestion_1',
+    userId: 'user_1',
+    name: 'Milk',
+    normalizedName: 'milk',
+    comment: '2%',
+    normalizedComment: '2%',
+    usageCount: 4,
+    lastUsedAt: new Date('2026-03-29T10:00:00.000Z'),
     createdAt: new Date('2026-03-29T10:00:00.000Z'),
     updatedAt: new Date('2026-03-29T10:00:00.000Z'),
     ...overrides
@@ -91,6 +120,7 @@ async function buildApp(
   userById: Map<string, TestUser | undefined>,
   listsById: Map<string, TestList | undefined>,
   itemsById: Map<string, TestItem | undefined>,
+  suggestionsById: Map<string, TestSuggestion | undefined> = new Map(),
   sessions: TestSession[] = []
 ) {
   const app = Fastify();
@@ -143,6 +173,105 @@ async function buildApp(
         session.lastUsedAt = data.lastUsedAt ?? session.lastUsedAt;
         session.updatedAt = data.lastUsedAt ?? session.updatedAt;
         return session;
+      }
+    },
+    itemSuggestion: {
+      findMany: async ({
+        where,
+        take
+      }: {
+        where: { userId: string };
+        orderBy: Array<{ usageCount?: 'asc' | 'desc' } | { lastUsedAt?: 'asc' | 'desc' } | { name?: 'asc' | 'desc' }>;
+        take: number;
+      }) => {
+        const suggestions = [...suggestionsById.values()]
+          .filter((suggestion): suggestion is TestSuggestion => Boolean(suggestion && suggestion.userId === where.userId))
+          .sort((left, right) => {
+            if (right.usageCount != left.usageCount) {
+              return right.usageCount - left.usageCount;
+            }
+
+            if (right.lastUsedAt.getTime() != left.lastUsedAt.getTime()) {
+              return right.lastUsedAt.getTime() - left.lastUsedAt.getTime();
+            }
+
+            return left.name.localeCompare(right.name);
+          });
+
+        return suggestions.slice(0, take);
+      },
+      findFirst: async ({
+        where
+      }: {
+        where: { userId: string; normalizedName: string; normalizedComment: string };
+      }) => {
+        return (
+          [...suggestionsById.values()].find(
+            (suggestion) =>
+              suggestion?.userId === where.userId &&
+              suggestion.normalizedName === where.normalizedName &&
+              suggestion.normalizedComment === where.normalizedComment
+          ) ?? null
+        );
+      },
+      create: async ({
+        data
+      }: {
+        data: {
+          userId: string;
+          name: string;
+          normalizedName: string;
+          comment?: string | null;
+          normalizedComment?: string;
+          usageCount: number;
+          lastUsedAt: Date;
+        };
+      }) => {
+        const suggestion = buildSuggestion({
+          id: `suggestion_${suggestionsById.size + 1}`,
+          userId: data.userId,
+          name: data.name,
+          normalizedName: data.normalizedName,
+          comment: data.comment ?? null,
+          normalizedComment: data.normalizedComment ?? '',
+          usageCount: data.usageCount,
+          lastUsedAt: data.lastUsedAt,
+          createdAt: data.lastUsedAt,
+          updatedAt: data.lastUsedAt
+        });
+
+        suggestionsById.set(suggestion.id, suggestion);
+        return suggestion;
+      },
+      update: async ({
+        where,
+        data
+      }: {
+        where: { id: string };
+        data: {
+          name?: string;
+          comment?: string | null;
+          usageCount?: { increment: number };
+          lastUsedAt?: Date;
+        };
+      }) => {
+        const suggestion = suggestionsById.get(where.id);
+
+        if (!suggestion) {
+          throw new Error('Suggestion not found');
+        }
+
+        const updatedSuggestion = {
+          ...suggestion,
+          name: data.name ?? suggestion.name,
+          comment: data.comment === undefined ? suggestion.comment : data.comment,
+          usageCount: suggestion.usageCount + (data.usageCount?.increment ?? 0),
+          lastUsedAt: data.lastUsedAt ?? suggestion.lastUsedAt,
+          updatedAt: data.lastUsedAt ?? suggestion.updatedAt
+        };
+
+        suggestionsById.set(where.id, updatedSuggestion);
+        return updatedSuggestion;
       }
     },
     shoppingList: {
@@ -205,8 +334,8 @@ async function buildApp(
         data: {
           listId: string;
           name: string;
-          quantity?: string | null;
-          unit?: string | null;
+          quantity: number;
+          comment?: string | null;
           isChecked: boolean;
           sortOrder: number;
           createdByUserId: string;
@@ -217,8 +346,8 @@ async function buildApp(
           id: `item_${itemsById.size + 1}`,
           listId: data.listId,
           name: data.name,
-          quantity: data.quantity ?? null,
-          unit: data.unit ?? null,
+          quantity: data.quantity,
+          comment: data.comment ?? null,
           isChecked: data.isChecked,
           sortOrder: data.sortOrder,
           createdByUserId: data.createdByUserId,
@@ -234,7 +363,7 @@ async function buildApp(
         data
       }: {
         where: { id: string };
-        data: { name?: string; quantity?: string | null; unit?: string | null; isChecked?: boolean };
+        data: { name?: string; quantity?: number; comment?: string | null; isChecked?: boolean };
       }) => {
         const item = itemsById.get(where.id);
 
@@ -246,7 +375,7 @@ async function buildApp(
           ...item,
           name: data.name ?? item.name,
           quantity: data.quantity === undefined ? item.quantity : data.quantity,
-          unit: data.unit === undefined ? item.unit : data.unit,
+          comment: data.comment === undefined ? item.comment : data.comment,
           isChecked: data.isChecked ?? item.isChecked,
           updatedAt: new Date('2026-03-30T10:00:00.000Z')
         };
@@ -290,6 +419,29 @@ function buildSessionToken(userId: string) {
   return { rawToken, session };
 }
 
+test('GET /items/suggestions returns ranked suggestions for the user', async () => {
+  const user = buildUser();
+  const suggestions = new Map<string, TestSuggestion | undefined>([
+    ['suggestion_1', buildSuggestion({ id: 'suggestion_1', userId: user.id, name: 'Milk', usageCount: 10 })],
+    ['suggestion_2', buildSuggestion({ id: 'suggestion_2', userId: user.id, name: 'Batteries', usageCount: 2 })]
+  ]);
+  const { rawToken, session } = buildSessionToken(user.id);
+  const app = await buildApp(new Map([[user.id, user]]), new Map(), new Map(), suggestions, [session]);
+
+  try {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/items/suggestions',
+      headers: { authorization: `Bearer ${rawToken}` }
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.json().items.map((item: { name: string }) => item.name), ['Milk', 'Batteries']);
+  } finally {
+    await app.close();
+  }
+});
+
 test('GET /lists/:listId/items returns items visible to the user ordered by sortOrder', async () => {
   const user = buildUser();
   const list = buildList({ memberIds: new Set([user.id]) });
@@ -298,7 +450,7 @@ test('GET /lists/:listId/items returns items visible to the user ordered by sort
     ['item_2', buildItem({ id: 'item_2', listId: list.id, name: 'Butter', sortOrder: 1, createdByUserId: user.id })]
   ]);
   const { rawToken, session } = buildSessionToken(user.id);
-  const app = await buildApp(new Map([[user.id, user]]), new Map([[list.id, list]]), items, [session]);
+  const app = await buildApp(new Map([[user.id, user]]), new Map([[list.id, list]]), items, new Map(), [session]);
 
   try {
     const response = await app.inject({
@@ -321,19 +473,23 @@ test('POST /lists/:listId/items creates a new item for a visible list', async ()
     ['item_1', buildItem({ id: 'item_1', listId: list.id, sortOrder: 0, createdByUserId: user.id })]
   ]);
   const { rawToken, session } = buildSessionToken(user.id);
-  const app = await buildApp(new Map([[user.id, user]]), new Map([[list.id, list]]), items, [session]);
+  const suggestions = new Map<string, TestSuggestion | undefined>();
+  const app = await buildApp(new Map([[user.id, user]]), new Map([[list.id, list]]), items, suggestions, [session]);
 
   try {
     const response = await app.inject({
       method: 'POST',
       url: `/lists/${list.id}/items`,
       headers: { authorization: `Bearer ${rawToken}` },
-      payload: { name: '  Apples  ', quantity: ' 2 ', unit: ' kg ' }
+      payload: { name: '  Apples  ', quantity: 2, comment: ' kg ' }
     });
 
     assert.equal(response.statusCode, 201);
     assert.equal(response.json().item.name, 'Apples');
+    assert.equal(response.json().item.quantity, 2);
+    assert.equal(response.json().item.comment, 'kg');
     assert.equal(items.size, 2);
+    assert.equal([...suggestions.values()][0]?.usageCount, 2);
   } finally {
     await app.close();
   }
@@ -342,20 +498,31 @@ test('POST /lists/:listId/items creates a new item for a visible list', async ()
 test('PATCH /lists/:listId/items/:itemId updates an item', async () => {
   const user = buildUser();
   const list = buildList({ memberIds: new Set([user.id]) });
-  const item = buildItem({ id: 'item_1', listId: list.id, name: 'Milk', quantity: '1', unit: 'l', isChecked: false, createdByUserId: user.id });
+  const item = buildItem({ id: 'item_1', listId: list.id, name: 'Milk', quantity: 1, comment: '2%', isChecked: false, createdByUserId: user.id });
   const { rawToken, session } = buildSessionToken(user.id);
-  const app = await buildApp(new Map([[user.id, user]]), new Map([[list.id, list]]), new Map([[item.id, item]]), [session]);
+  const suggestions = new Map<string, TestSuggestion | undefined>([
+    ['suggestion_1', buildSuggestion({ id: 'suggestion_1', userId: user.id, name: 'Milk', comment: '2%', normalizedComment: '2%', usageCount: 4 })]
+  ]);
+  const app = await buildApp(
+    new Map([[user.id, user]]),
+    new Map([[list.id, list]]),
+    new Map([[item.id, item]]),
+    suggestions,
+    [session]
+  );
 
   try {
     const response = await app.inject({
       method: 'PATCH',
       url: `/lists/${list.id}/items/${item.id}`,
       headers: { authorization: `Bearer ${rawToken}` },
-      payload: { name: 'Oat milk', isChecked: true }
+      payload: { name: 'Oat milk', quantity: 3, comment: 'Barista', isChecked: true }
     });
 
     assert.equal(response.statusCode, 200);
     assert.equal(response.json().item.name, 'Oat milk');
+    assert.equal(response.json().item.quantity, 3);
+    assert.equal(response.json().item.comment, 'Barista');
     assert.equal(response.json().item.isChecked, true);
   } finally {
     await app.close();
@@ -368,7 +535,7 @@ test('DELETE /lists/:listId/items/:itemId removes the item', async () => {
   const item = buildItem({ id: 'item_1', listId: list.id, createdByUserId: user.id });
   const { rawToken, session } = buildSessionToken(user.id);
   const items = new Map<string, TestItem | undefined>([[item.id, item]]);
-  const app = await buildApp(new Map([[user.id, user]]), new Map([[list.id, list]]), items, [session]);
+  const app = await buildApp(new Map([[user.id, user]]), new Map([[list.id, list]]), items, new Map(), [session]);
 
   try {
     const response = await app.inject({
@@ -388,7 +555,7 @@ test('GET /lists/:listId/items returns 404 for a list the user cannot access', a
   const user = buildUser();
   const list = buildList({ ownerUserId: 'user_2', memberIds: new Set(['user_2']) });
   const { rawToken, session } = buildSessionToken(user.id);
-  const app = await buildApp(new Map([[user.id, user]]), new Map([[list.id, list]]), new Map(), [session]);
+  const app = await buildApp(new Map([[user.id, user]]), new Map([[list.id, list]]), new Map(), new Map(), [session]);
 
   try {
     const response = await app.inject({

--- a/backend/src/modules/items/routes.ts
+++ b/backend/src/modules/items/routes.ts
@@ -9,8 +9,8 @@ type ItemResponse = {
   id: string;
   listId: string;
   name: string;
-  quantity: string | null;
-  unit: string | null;
+  quantity: number;
+  comment: string | null;
   isChecked: boolean;
   sortOrder: number;
   createdByUserId: string;
@@ -22,11 +22,32 @@ type ItemRecord = {
   id: string;
   listId: string;
   name: string;
-  quantity: string | null;
-  unit: string | null;
+  quantity: number;
+  comment: string | null;
   isChecked: boolean;
   sortOrder: number;
   createdByUserId: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type ItemSuggestionResponse = {
+  id: string;
+  name: string;
+  comment: string | null;
+  usageCount: number;
+  lastUsedAt: Date;
+};
+
+type ItemSuggestionRecord = {
+  id: string;
+  userId: string;
+  name: string;
+  normalizedName: string;
+  comment: string | null;
+  normalizedComment: string;
+  usageCount: number;
+  lastUsedAt: Date;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -52,8 +73,8 @@ type ItemRepository = {
     data: {
       listId: string;
       name: string;
-      quantity?: string | null;
-      unit?: string | null;
+      quantity: number;
+      comment?: string | null;
       isChecked: boolean;
       sortOrder: number;
       createdByUserId: string;
@@ -63,8 +84,8 @@ type ItemRepository = {
     where: { id: string };
     data: {
       name?: string;
-      quantity?: string | null;
-      unit?: string | null;
+      quantity?: number;
+      comment?: string | null;
       isChecked?: boolean;
     };
   }): Promise<ItemRecord>;
@@ -118,6 +139,40 @@ type AuthSessionRepository = {
 type ItemRoutesDeps = {
   prisma: {
     listItem: ItemRepository;
+    itemSuggestion: {
+      findMany(args: {
+        where: { userId: string };
+        orderBy: Array<{ usageCount?: 'asc' | 'desc' } | { lastUsedAt?: 'asc' | 'desc' } | { name?: 'asc' | 'desc' }>;
+        take: number;
+      }): Promise<ItemSuggestionRecord[]>;
+      findFirst(args: {
+        where: {
+          userId: string;
+          normalizedName: string;
+          normalizedComment: string;
+        };
+      }): Promise<ItemSuggestionRecord | null>;
+      create(args: {
+        data: {
+          userId: string;
+          name: string;
+          normalizedName: string;
+          comment?: string | null;
+          normalizedComment?: string;
+          usageCount: number;
+          lastUsedAt: Date;
+        };
+      }): Promise<ItemSuggestionRecord>;
+      update(args: {
+        where: { id: string };
+        data: {
+          name?: string;
+          comment?: string | null;
+          usageCount?: { increment: number };
+          lastUsedAt?: Date;
+        };
+      }): Promise<ItemSuggestionRecord>;
+    };
     shoppingList: ListRepository;
     user: UserRepository;
     authSession: AuthSessionRepository;
@@ -126,14 +181,14 @@ type ItemRoutesDeps = {
 
 const itemBodySchema = z.object({
   name: z.string().trim().min(1).max(100),
-  quantity: z.union([z.string().trim().min(1).max(50), z.null()]).optional(),
-  unit: z.union([z.string().trim().min(1).max(50), z.null()]).optional()
+  quantity: z.coerce.number().int().min(1).max(999).optional(),
+  comment: z.union([z.string().trim().min(1).max(140), z.null()]).optional()
 });
 
 const updateItemBodySchema = z.object({
   name: z.string().trim().min(1).max(100).optional(),
-  quantity: z.union([z.string().trim().min(1).max(50), z.null()]).optional(),
-  unit: z.union([z.string().trim().min(1).max(50), z.null()]).optional(),
+  quantity: z.coerce.number().int().min(1).max(999).optional(),
+  comment: z.union([z.string().trim().min(1).max(140), z.null()]).optional(),
   isChecked: z.boolean().optional()
 });
 
@@ -148,7 +203,7 @@ function toItemResponse(
     | 'listId'
     | 'name'
     | 'quantity'
-    | 'unit'
+    | 'comment'
     | 'isChecked'
     | 'sortOrder'
     | 'createdByUserId'
@@ -161,12 +216,22 @@ function toItemResponse(
     listId: item.listId,
     name: item.name,
     quantity: item.quantity,
-    unit: item.unit,
+    comment: item.comment,
     isChecked: item.isChecked,
     sortOrder: item.sortOrder,
     createdByUserId: item.createdByUserId,
     createdAt: item.createdAt,
     updatedAt: item.updatedAt
+  };
+}
+
+function toSuggestionResponse(suggestion: ItemSuggestionRecord): ItemSuggestionResponse {
+  return {
+    id: suggestion.id,
+    name: suggestion.name,
+    comment: suggestion.comment,
+    usageCount: suggestion.usageCount,
+    lastUsedAt: suggestion.lastUsedAt
   };
 }
 
@@ -232,8 +297,96 @@ async function getNextSortOrder(deps: ItemRoutesDeps, listId: string) {
   return (latestItem?.sortOrder ?? -1) + 1;
 }
 
+function normalizeSuggestionPart(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? '';
+  return trimmed.length == 0 ? null : trimmed.toLowerCase();
+}
+
+async function recordSuggestionUsage(
+  deps: ItemRoutesDeps,
+  userId: string,
+  {
+    name,
+    comment,
+    incrementBy
+  }: {
+    name: string;
+    comment?: string | null;
+    incrementBy: number;
+  }
+) {
+  if (incrementBy <= 0) {
+    return;
+  }
+
+  const normalizedName = normalizeSuggestionPart(name);
+  const normalizedComment = normalizeSuggestionPart(comment) ?? '';
+
+  if (normalizedName == null) {
+    return;
+  }
+
+  const now = new Date();
+  const existingSuggestion = await deps.prisma.itemSuggestion.findFirst({
+    where: {
+      userId,
+      normalizedName,
+      normalizedComment
+    }
+  });
+
+  if (existingSuggestion) {
+    await deps.prisma.itemSuggestion.update({
+      where: {
+        id: existingSuggestion.id
+      },
+      data: {
+        name: name.trim(),
+        comment: comment?.trim() ?? null,
+        usageCount: {
+          increment: incrementBy
+        },
+        lastUsedAt: now
+      }
+    });
+    return;
+  }
+
+  await deps.prisma.itemSuggestion.create({
+    data: {
+      userId,
+      name: name.trim(),
+      normalizedName,
+      comment: comment?.trim() ?? null,
+      normalizedComment,
+      usageCount: incrementBy,
+      lastUsedAt: now
+    }
+  });
+}
+
 export function createItemRoutes(deps: ItemRoutesDeps = defaultDeps): FastifyPluginAsync {
   return async (app) => {
+    app.get('/items/suggestions', async (request, reply) => {
+      const user = await authenticateRequest(deps.prisma, request, reply);
+
+      if (!user) {
+        return;
+      }
+
+      const suggestions = await deps.prisma.itemSuggestion.findMany({
+        where: {
+          userId: user.id
+        },
+        orderBy: [{ usageCount: 'desc' }, { lastUsedAt: 'desc' }, { name: 'asc' }],
+        take: 12
+      });
+
+      return {
+        items: suggestions.map(toSuggestionResponse)
+      };
+    });
+
     app.get('/lists/:listId/items', async (request, reply) => {
       const user = await authenticateRequest(deps.prisma, request, reply);
 
@@ -287,12 +440,18 @@ export function createItemRoutes(deps: ItemRoutesDeps = defaultDeps): FastifyPlu
         data: {
           listId,
           name: body.name,
-          quantity: body.quantity ?? null,
-          unit: body.unit ?? null,
+          quantity: body.quantity ?? 1,
+          comment: body.comment ?? null,
           isChecked: false,
           sortOrder,
           createdByUserId: user.id
         }
+      });
+
+      await recordSuggestionUsage(deps, user.id, {
+        name: item.name,
+        comment: item.comment,
+        incrementBy: item.quantity
       });
 
       return reply.code(201).send({
@@ -330,6 +489,10 @@ export function createItemRoutes(deps: ItemRoutesDeps = defaultDeps): FastifyPlu
         return reply.notFound('Item not found');
       }
 
+      const nextName = body.name ?? existingItem.name;
+      const nextComment = body.comment === undefined ? existingItem.comment : body.comment;
+      const nextQuantity = body.quantity ?? existingItem.quantity;
+
       const item = await deps.prisma.listItem.update({
         where: {
           id: existingItem.id
@@ -337,9 +500,15 @@ export function createItemRoutes(deps: ItemRoutesDeps = defaultDeps): FastifyPlu
         data: {
           name: body.name,
           quantity: body.quantity,
-          unit: body.unit,
+          comment: body.comment,
           isChecked: body.isChecked
         }
+      });
+
+      await recordSuggestionUsage(deps, user.id, {
+        name: nextName,
+        comment: nextComment,
+        incrementBy: Math.max(nextQuantity - existingItem.quantity, 0)
       });
 
       return {

--- a/docs/api.md
+++ b/docs/api.md
@@ -367,8 +367,8 @@ Response:
       "id": "item_id",
       "listId": "list_id",
       "name": "Milk",
-      "quantity": "2",
-      "unit": "l",
+      "quantity": 2,
+      "comment": "2%",
       "isChecked": false,
       "sortOrder": 0,
       "createdByUserId": "user_id",
@@ -392,8 +392,8 @@ Request body:
 ```json
 {
   "name": "Milk",
-  "quantity": "2",
-  "unit": "l"
+  "quantity": 2,
+  "comment": "2%"
 }
 ```
 
@@ -405,8 +405,8 @@ Response:
     "id": "item_id",
     "listId": "list_id",
     "name": "Milk",
-    "quantity": "2",
-    "unit": "l",
+    "quantity": 2,
+    "comment": "2%",
     "isChecked": false,
     "sortOrder": 0,
     "createdByUserId": "user_id",
@@ -418,7 +418,8 @@ Response:
 
 Notes:
 - the item is created with the next `sortOrder` value on the server
-- `quantity` and `unit` are optional
+- `quantity` defaults to `1`
+- `comment` is optional
 
 ### `PATCH /lists/:listId/items/:itemId`
 
@@ -433,8 +434,8 @@ Request body:
 ```json
 {
   "name": "Oat milk",
-  "quantity": "2",
-  "unit": "l",
+  "quantity": 3,
+  "comment": "Barista",
   "isChecked": true
 }
 ```
@@ -447,8 +448,8 @@ Response:
     "id": "item_id",
     "listId": "list_id",
     "name": "Oat milk",
-    "quantity": "2",
-    "unit": "l",
+    "quantity": 3,
+    "comment": "Barista",
     "isChecked": true,
     "sortOrder": 0,
     "createdByUserId": "user_id",
@@ -461,6 +462,34 @@ Response:
 Notes:
 - send only the fields you want to change
 - empty update bodies return `400 Bad Request`
+
+### `GET /items/suggestions`
+
+Headers:
+
+```http
+Authorization: Bearer jwt-token
+```
+
+Response:
+
+```json
+{
+  "items": [
+    {
+      "id": "suggestion_id",
+      "name": "Milk",
+      "comment": "2%",
+      "usageCount": 12,
+      "lastUsedAt": "2026-04-11T12:00:00.000Z"
+    }
+  ]
+}
+```
+
+Notes:
+- suggestions are ranked by `usageCount`, then by most recent use
+- usage is updated when a user creates an item or increases its quantity
 
 ### `DELETE /lists/:listId/items/:itemId`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -224,10 +224,22 @@ NestJS is also valid, but Fastify keeps the first version leaner.
 - `list_id`
 - `name`
 - `quantity`
-- `unit`
+- `comment`
 - `is_checked`
 - `sort_order`
 - `created_by_user_id`
+- `created_at`
+- `updated_at`
+
+#### item_suggestions
+- `id`
+- `user_id`
+- `name`
+- `normalized_name`
+- `comment`
+- `normalized_comment`
+- `usage_count`
+- `last_used_at`
 - `created_at`
 - `updated_at`
 
@@ -327,6 +339,7 @@ Magic links can be added later, but the initial contract should assume numeric o
 - `DELETE /lists/:listId/members/:userId`
 
 #### items
+- `GET /items/suggestions`
 - `GET /lists/:listId/items`
 - `POST /lists/:listId/items`
 - `PATCH /lists/:listId/items/:itemId`

--- a/mobile/lib/core/network/api_client.dart
+++ b/mobile/lib/core/network/api_client.dart
@@ -108,8 +108,7 @@ class ApiClient {
     return _guard(() async {
       final response = await _dio.get<Map<String, dynamic>>(
         '/lists',
-        queryParameters:
-            includeArchived ? {'includeArchived': 'true'} : null,
+        queryParameters: includeArchived ? {'includeArchived': 'true'} : null,
         options: _authOptions(),
       );
       final items =
@@ -218,6 +217,20 @@ class ApiClient {
               .cast<Map<String, dynamic>>();
 
       return items.map(ShoppingListItem.fromJson).toList(growable: false);
+    });
+  }
+
+  Future<List<ItemSuggestion>> fetchItemSuggestions() {
+    return _guard(() async {
+      final response = await _dio.get<Map<String, dynamic>>(
+        '/items/suggestions',
+        options: _authOptions(),
+      );
+      final items =
+          (response.data?['items'] as List<dynamic>? ?? const <dynamic>[])
+              .cast<Map<String, dynamic>>();
+
+      return items.map(ItemSuggestion.fromJson).toList(growable: false);
     });
   }
 
@@ -427,26 +440,26 @@ class ShoppingListSummary {
 class ItemDraft {
   const ItemDraft({
     required this.name,
-    this.quantity,
-    this.unit,
+    this.comment,
+    this.quantity = 1,
     this.isChecked = false,
   });
 
   final String name;
-  final String? quantity;
-  final String? unit;
+  final String? comment;
+  final int quantity;
   final bool isChecked;
 
   ItemDraft copyWith({
     String? name,
-    String? quantity,
-    String? unit,
+    String? comment,
+    int? quantity,
     bool? isChecked,
   }) {
     return ItemDraft(
       name: name ?? this.name,
+      comment: comment ?? this.comment,
       quantity: quantity ?? this.quantity,
-      unit: unit ?? this.unit,
       isChecked: isChecked ?? this.isChecked,
     );
   }
@@ -454,8 +467,8 @@ class ItemDraft {
   Map<String, dynamic> toJson() {
     return {
       'name': name,
+      'comment': comment,
       'quantity': quantity,
-      'unit': unit,
       'isChecked': isChecked,
     };
   }
@@ -466,8 +479,8 @@ class ShoppingListItem {
     required this.id,
     required this.listId,
     required this.name,
+    required this.comment,
     required this.quantity,
-    required this.unit,
     required this.isChecked,
     required this.sortOrder,
     required this.createdByUserId,
@@ -478,8 +491,8 @@ class ShoppingListItem {
   final String id;
   final String listId;
   final String name;
-  final String? quantity;
-  final String? unit;
+  final String? comment;
+  final int quantity;
   final bool isChecked;
   final int sortOrder;
   final String createdByUserId;
@@ -491,8 +504,8 @@ class ShoppingListItem {
       id: json['id'] as String,
       listId: json['listId'] as String,
       name: json['name'] as String,
-      quantity: json['quantity'] as String?,
-      unit: json['unit'] as String?,
+      comment: json['comment'] as String?,
+      quantity: json['quantity'] as int? ?? 1,
       isChecked: json['isChecked'] as bool? ?? false,
       sortOrder: json['sortOrder'] as int? ?? 0,
       createdByUserId: json['createdByUserId'] as String,
@@ -504,8 +517,8 @@ class ShoppingListItem {
   ItemDraft toDraft() {
     return ItemDraft(
       name: name,
+      comment: comment,
       quantity: quantity,
-      unit: unit,
       isChecked: isChecked,
     );
   }
@@ -514,8 +527,8 @@ class ShoppingListItem {
     String? id,
     String? listId,
     String? name,
-    String? quantity,
-    String? unit,
+    String? comment,
+    int? quantity,
     bool? isChecked,
     int? sortOrder,
     String? createdByUserId,
@@ -526,13 +539,39 @@ class ShoppingListItem {
       id: id ?? this.id,
       listId: listId ?? this.listId,
       name: name ?? this.name,
+      comment: comment ?? this.comment,
       quantity: quantity ?? this.quantity,
-      unit: unit ?? this.unit,
       isChecked: isChecked ?? this.isChecked,
       sortOrder: sortOrder ?? this.sortOrder,
       createdByUserId: createdByUserId ?? this.createdByUserId,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+}
+
+class ItemSuggestion {
+  const ItemSuggestion({
+    required this.id,
+    required this.name,
+    required this.comment,
+    required this.usageCount,
+    required this.lastUsedAt,
+  });
+
+  final String id;
+  final String name;
+  final String? comment;
+  final int usageCount;
+  final DateTime lastUsedAt;
+
+  factory ItemSuggestion.fromJson(Map<String, dynamic> json) {
+    return ItemSuggestion(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      comment: json['comment'] as String?,
+      usageCount: json['usageCount'] as int? ?? 0,
+      lastUsedAt: DateTime.parse(json['lastUsedAt'] as String),
     );
   }
 }
@@ -639,8 +678,7 @@ class ShareListResult {
     this.invitation,
   });
 
-  const ShareListResult.member(ListMember member)
-      : this._(member: member);
+  const ShareListResult.member(ListMember member) : this._(member: member);
 
   const ShareListResult.invitation(PendingListInvitation invitation)
       : this._(invitation: invitation);

--- a/mobile/lib/features/lists/list_detail_page.dart
+++ b/mobile/lib/features/lists/list_detail_page.dart
@@ -32,6 +32,7 @@ class ListDetailPage extends StatefulWidget {
 
 class _ListDetailPageState extends State<ListDetailPage> {
   final List<ShoppingListItem> _items = <ShoppingListItem>[];
+  final List<ItemSuggestion> _suggestions = <ItemSuggestion>[];
   final Set<String> _pendingItemIds = <String>{};
   final Map<String, _PendingItemMutation> _pendingItemMutations =
       <String, _PendingItemMutation>{};
@@ -54,9 +55,11 @@ class _ListDetailPageState extends State<ListDetailPage> {
     _listName = widget.listName ?? 'List ${widget.listId}';
     _isArchived = widget.isArchived;
     _reloadItems();
+    _reloadSuggestions();
     _refreshTimer = Timer.periodic(const Duration(seconds: 15), (_) {
       if (mounted) {
         _reloadItems(silent: true);
+        _reloadSuggestions(silent: true);
       }
     });
   }
@@ -112,24 +115,43 @@ class _ListDetailPageState extends State<ListDetailPage> {
 
       if (hasExistingItems) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Could not refresh items: $message')),
+          SnackBar(
+              content: Text('Nie udało się odświeżyć produktów: $message')),
         );
       }
     }
   }
 
-  Future<void> _addItem() async {
-    final draft = await showDialog<ItemDraft>(
-      context: context,
-      builder: (context) {
-        return const _ItemEditorDialog();
-      },
-    );
+  Future<void> _reloadSuggestions({bool silent = false}) async {
+    try {
+      final suggestions = await widget.apiClient.fetchItemSuggestions();
 
-    if (draft == null) {
-      return;
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _suggestions
+          ..clear()
+          ..addAll(suggestions);
+      });
+    } on ApiException catch (error) {
+      if (error.isUnauthorized && widget.onUnauthorized != null) {
+        await widget.onUnauthorized!();
+        return;
+      }
+
+      if (!silent && mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Nie udało się pobrać sugestii: ${error.message}'),
+          ),
+        );
+      }
     }
+  }
 
+  Future<void> _createItemFromDraft(ItemDraft draft) async {
     final temporaryId = _nextTemporaryItemId();
     final optimisticItem = _buildOptimisticItem(
       id: temporaryId,
@@ -164,6 +186,8 @@ class _ListDetailPageState extends State<ListDetailPage> {
         upsertById(target: _items, value: createdItem, idOf: (item) => item.id);
         _sortItems();
       });
+
+      unawaited(_reloadSuggestions(silent: true));
     } on ApiException catch (error) {
       if (error.isUnauthorized && widget.onUnauthorized != null) {
         await widget.onUnauthorized!();
@@ -181,9 +205,25 @@ class _ListDetailPageState extends State<ListDetailPage> {
       });
 
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Could not add item: ${error.message}')),
+        SnackBar(
+            content: Text('Nie udało się dodać produktu: ${error.message}')),
       );
     }
+  }
+
+  Future<void> _addItem() async {
+    final draft = await showDialog<ItemDraft>(
+      context: context,
+      builder: (context) {
+        return const _ItemEditorDialog();
+      },
+    );
+
+    if (draft == null) {
+      return;
+    }
+
+    await _createItemFromDraft(draft);
   }
 
   Future<void> _editItem(ShoppingListItem item) async {
@@ -206,8 +246,8 @@ class _ListDetailPageState extends State<ListDetailPage> {
     final previousItem = _items[existingIndex];
     final optimisticItem = previousItem.copyWith(
       name: draft.name,
+      comment: draft.comment,
       quantity: draft.quantity,
-      unit: draft.unit,
       isChecked: draft.isChecked,
     );
 
@@ -243,6 +283,8 @@ class _ListDetailPageState extends State<ListDetailPage> {
         );
         _sortItems();
       });
+
+      unawaited(_reloadSuggestions(silent: true));
     } on ApiException catch (error) {
       if (error.isUnauthorized && widget.onUnauthorized != null) {
         await widget.onUnauthorized!();
@@ -265,7 +307,8 @@ class _ListDetailPageState extends State<ListDetailPage> {
       });
 
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Could not save item: ${error.message}')),
+        SnackBar(
+            content: Text('Nie udało się zapisać produktu: ${error.message}')),
       );
     }
   }
@@ -339,9 +382,121 @@ class _ListDetailPageState extends State<ListDetailPage> {
       });
 
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Could not update item: ${error.message}')),
+        SnackBar(
+            content:
+                Text('Nie udało się zaktualizować produktu: ${error.message}')),
       );
     }
+  }
+
+  Future<void> _changeQuantity(ShoppingListItem item, int delta) async {
+    final existingIndex = _items.indexWhere((entry) => entry.id == item.id);
+    if (existingIndex == -1) {
+      return;
+    }
+
+    final previousItem = _items[existingIndex];
+    final nextQuantity = previousItem.quantity + delta;
+    if (nextQuantity < 1) {
+      return;
+    }
+
+    final optimisticDraft = previousItem.toDraft().copyWith(
+          quantity: nextQuantity,
+        );
+    final optimisticItem = previousItem.copyWith(quantity: nextQuantity);
+
+    setState(() {
+      _didMutateList = true;
+      _pendingItemIds.add(item.id);
+      _pendingItemMutations[item.id] = _PendingItemMutation.update(
+        previousItem: previousItem,
+        optimisticItem: optimisticItem,
+      );
+      _items[existingIndex] = optimisticItem;
+      _sortItems();
+    });
+
+    try {
+      final updatedItem = await widget.apiClient.updateItem(
+        widget.listId,
+        item.id,
+        optimisticDraft,
+      );
+
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _pendingItemIds.remove(item.id);
+        _pendingItemMutations.remove(item.id);
+        upsertById(
+          target: _items,
+          value: updatedItem,
+          idOf: (entry) => entry.id,
+        );
+        _sortItems();
+      });
+
+      if (delta > 0) {
+        unawaited(_reloadSuggestions(silent: true));
+      }
+    } on ApiException catch (error) {
+      if (error.isUnauthorized && widget.onUnauthorized != null) {
+        await widget.onUnauthorized!();
+        return;
+      }
+
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _pendingItemIds.remove(item.id);
+        _pendingItemMutations.remove(item.id);
+        upsertById(
+          target: _items,
+          value: previousItem,
+          idOf: (entry) => entry.id,
+        );
+        _sortItems();
+      });
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+            content: Text('Nie udało się zmienić ilości: ${error.message}')),
+      );
+    }
+  }
+
+  Future<void> _addSuggestion(ItemSuggestion suggestion) async {
+    ShoppingListItem? existingItem;
+
+    for (final item in _items) {
+      final matchesName = item.name.trim().toLowerCase() ==
+          suggestion.name.trim().toLowerCase();
+      final matchesComment = (item.comment?.trim().toLowerCase() ?? '') ==
+          (suggestion.comment?.trim().toLowerCase() ?? '');
+
+      if (!item.isChecked && matchesName && matchesComment) {
+        existingItem = item;
+        break;
+      }
+    }
+
+    if (existingItem != null) {
+      await _changeQuantity(existingItem, 1);
+      return;
+    }
+
+    await _createItemFromDraft(
+      ItemDraft(
+        name: suggestion.name,
+        comment: suggestion.comment,
+        quantity: 1,
+      ),
+    );
   }
 
   Future<void> _deleteItem(ShoppingListItem item) async {
@@ -349,16 +504,16 @@ class _ListDetailPageState extends State<ListDetailPage> {
       context: context,
       builder: (context) {
         return AlertDialog(
-          title: const Text('Delete item'),
-          content: Text('Delete "${item.name}"?'),
+          title: const Text('Usuń produkt'),
+          content: Text('Usunąć "${item.name}"?'),
           actions: [
             TextButton(
               onPressed: () => Navigator.of(context).pop(false),
-              child: const Text('Cancel'),
+              child: const Text('Anuluj'),
             ),
             FilledButton(
               onPressed: () => Navigator.of(context).pop(true),
-              child: const Text('Delete'),
+              child: const Text('Usuń'),
             ),
           ],
         );
@@ -415,7 +570,8 @@ class _ListDetailPageState extends State<ListDetailPage> {
       });
 
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Could not delete item: ${error.message}')),
+        SnackBar(
+            content: Text('Nie udało się usunąć produktu: ${error.message}')),
       );
     }
   }
@@ -451,8 +607,8 @@ class _ListDetailPageState extends State<ListDetailPage> {
       }
 
       final message = result.member != null
-          ? 'Shared with ${result.member!.user.email}.'
-          : 'List shared with ${result.invitation!.email}. It will appear after they sign in.';
+          ? 'Udostępniono ${result.member!.user.email}.'
+          : 'Udostępniono ${result.invitation!.email}. Lista pojawi się po zalogowaniu.';
 
       ScaffoldMessenger.of(
         context,
@@ -488,9 +644,9 @@ class _ListDetailPageState extends State<ListDetailPage> {
       context: context,
       builder: (context) {
         return _ListNameDialog(
-          title: 'Rename list',
+          title: 'Zmień nazwę listy',
           initialValue: _listName,
-          actionLabel: 'Save',
+          actionLabel: 'Zapisz',
         );
       },
     );
@@ -515,7 +671,7 @@ class _ListDetailPageState extends State<ListDetailPage> {
       });
 
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Renamed to ${updatedList.name}.')),
+        SnackBar(content: Text('Zmieniono nazwę na ${updatedList.name}.')),
       );
     } on ApiException catch (error) {
       if (error.isUnauthorized && widget.onUnauthorized != null) {
@@ -528,7 +684,9 @@ class _ListDetailPageState extends State<ListDetailPage> {
       }
 
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Could not rename list: ${error.message}')),
+        SnackBar(
+            content:
+                Text('Nie udało się zmienić nazwy listy: ${error.message}')),
       );
     }
   }
@@ -556,8 +714,8 @@ class _ListDetailPageState extends State<ListDetailPage> {
         SnackBar(
           content: Text(
             updatedList.isArchived
-                ? 'List moved to archive.'
-                : 'List restored.',
+                ? 'Lista przeniesiona do archiwum.'
+                : 'Lista przywrócona.',
           ),
         ),
       );
@@ -577,8 +735,8 @@ class _ListDetailPageState extends State<ListDetailPage> {
         SnackBar(
           content: Text(
             _isArchived
-                ? 'Could not restore list: ${error.message}'
-                : 'Could not archive list: ${error.message}',
+                ? 'Nie udało się przywrócić listy: ${error.message}'
+                : 'Nie udało się zarchiwizować listy: ${error.message}',
           ),
         ),
       );
@@ -627,17 +785,19 @@ class _ListDetailPageState extends State<ListDetailPage> {
                 PopupMenuItem<_ListAction>(
                   value: _ListAction.share,
                   enabled: !_isSharing,
-                  child: const Text('Share list'),
+                  child: const Text('Udostępnij listę'),
                 ),
                 if (widget.canManageList)
                   const PopupMenuItem<_ListAction>(
                     value: _ListAction.rename,
-                    child: Text('Rename list'),
+                    child: Text('Zmień nazwę listy'),
                   ),
                 if (widget.canManageList)
                   PopupMenuItem<_ListAction>(
                     value: _ListAction.archive,
-                    child: Text(_isArchived ? 'Restore list' : 'Archive list'),
+                    child: Text(
+                      _isArchived ? 'Przywróć listę' : 'Archiwizuj listę',
+                    ),
                   ),
               ],
             ),
@@ -648,7 +808,10 @@ class _ListDetailPageState extends State<ListDetailPage> {
           child: const Icon(Icons.add),
         ),
         body: RefreshIndicator(
-          onRefresh: () => _reloadItems(silent: true),
+          onRefresh: () async {
+            await _reloadItems(silent: true);
+            await _reloadSuggestions(silent: true);
+          },
           child: _buildBody(context),
         ),
       ),
@@ -694,7 +857,7 @@ class _ListDetailPageState extends State<ListDetailPage> {
               isPending ? null : (checked) => _onToggleRequested(item, checked),
         ),
         title: Text(
-          item.name,
+          '${item.name} (${item.quantity})',
           style: TextStyle(
             decoration: item.isChecked
                 ? TextDecoration.lineThrough
@@ -705,6 +868,18 @@ class _ListDetailPageState extends State<ListDetailPage> {
         trailing: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
+            IconButton(
+              onPressed: isPending || item.quantity <= 1
+                  ? null
+                  : () => _changeQuantity(item, -1),
+              icon: const Icon(Icons.remove_circle_outline),
+              tooltip: 'Zmniejsz ilość',
+            ),
+            IconButton(
+              onPressed: isPending ? null : () => _changeQuantity(item, 1),
+              icon: const Icon(Icons.add_circle_outline),
+              tooltip: 'Zwiększ ilość',
+            ),
             IconButton(
               onPressed: isPending ? null : () => _onEditRequested(item),
               icon: const Icon(Icons.edit_outlined),
@@ -806,8 +981,8 @@ class _ListDetailPageState extends State<ListDetailPage> {
       id: id,
       listId: widget.listId,
       name: draft.name,
+      comment: draft.comment,
       quantity: draft.quantity,
-      unit: draft.unit,
       isChecked: draft.isChecked,
       sortOrder: sortOrder,
       createdByUserId: 'pending',
@@ -839,7 +1014,7 @@ class _ListDetailPageState extends State<ListDetailPage> {
                 const Icon(Icons.error_outline, size: 48),
                 const SizedBox(height: 12),
                 Text(
-                  'Could not load items',
+                  'Nie udało się wczytać produktów',
                   style: Theme.of(context).textTheme.titleMedium,
                 ),
                 const SizedBox(height: 8),
@@ -850,7 +1025,7 @@ class _ListDetailPageState extends State<ListDetailPage> {
                 const SizedBox(height: 16),
                 FilledButton(
                   onPressed: () => _reloadItems(),
-                  child: const Text('Retry'),
+                  child: const Text('Spróbuj ponownie'),
                 ),
               ],
             ),
@@ -862,42 +1037,78 @@ class _ListDetailPageState extends State<ListDetailPage> {
     if (_items.isEmpty) {
       return ListView(
         physics: const AlwaysScrollableScrollPhysics(),
-        children: const [
-          SizedBox(height: 160),
-          Center(child: Text('No items yet. Add the first one.')),
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 96),
+        children: [
+          const SizedBox(height: 160),
+          const Center(child: Text('Brak produktów. Dodaj pierwszy.')),
+          if (_suggestions.isNotEmpty) ...[
+            const SizedBox(height: 24),
+            _buildSuggestionsSection(context),
+          ],
         ],
       );
     }
 
-    return ListView.separated(
+    return ListView(
       physics: const AlwaysScrollableScrollPhysics(),
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 96),
-      itemCount: _items.length,
-      separatorBuilder: (context, index) => const SizedBox(height: 8),
-      itemBuilder: (context, index) {
-        final item = _items[index];
-
-        return _buildItemTile(item);
-      },
+      children: [
+        for (final item in _items) ...[
+          _buildItemTile(item),
+          const SizedBox(height: 8),
+        ],
+        if (_suggestions.isNotEmpty) _buildSuggestionsSection(context),
+      ],
     );
   }
 
   Widget? _buildSubtitle(ShoppingListItem item) {
-    final details = <String>[];
-
-    if (item.quantity != null && item.quantity!.isNotEmpty) {
-      details.add(item.quantity!);
-    }
-
-    if (item.unit != null && item.unit!.isNotEmpty) {
-      details.add(item.unit!);
-    }
-
-    if (details.isEmpty) {
+    if (item.comment == null || item.comment!.isEmpty) {
       return null;
     }
 
-    return Text(details.join(' '));
+    return Text(item.comment!);
+  }
+
+  Widget _buildSuggestionsSection(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 16),
+        Text(
+          'Sugestie',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Najczęściej dodawane produkty',
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+        ),
+        const SizedBox(height: 12),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: _suggestions
+              .map(
+                (suggestion) => ActionChip(
+                  backgroundColor: Theme.of(context)
+                      .colorScheme
+                      .surfaceContainerHighest
+                      .withValues(alpha: 0.6),
+                  label: Text(
+                    suggestion.comment == null || suggestion.comment!.isEmpty
+                        ? suggestion.name
+                        : '${suggestion.name} • ${suggestion.comment}',
+                  ),
+                  onPressed: () => _addSuggestion(suggestion),
+                ),
+              )
+              .toList(growable: false),
+        ),
+      ],
+    );
   }
 }
 
@@ -958,9 +1169,8 @@ class _ItemEditorDialog extends StatefulWidget {
 class _ItemEditorDialogState extends State<_ItemEditorDialog> {
   final _formKey = GlobalKey<FormState>();
   late final TextEditingController _nameController;
-  late final TextEditingController _quantityController;
-  late final TextEditingController _unitController;
   late bool _isChecked;
+  late final TextEditingController _commentController;
 
   @override
   void initState() {
@@ -968,11 +1178,8 @@ class _ItemEditorDialogState extends State<_ItemEditorDialog> {
     _nameController = TextEditingController(
       text: widget.initialItem?.name ?? '',
     );
-    _quantityController = TextEditingController(
-      text: widget.initialItem?.quantity ?? '',
-    );
-    _unitController = TextEditingController(
-      text: widget.initialItem?.unit ?? '',
+    _commentController = TextEditingController(
+      text: widget.initialItem?.comment ?? '',
     );
     _isChecked = widget.initialItem?.isChecked ?? false;
   }
@@ -980,8 +1187,7 @@ class _ItemEditorDialogState extends State<_ItemEditorDialog> {
   @override
   void dispose() {
     _nameController.dispose();
-    _quantityController.dispose();
-    _unitController.dispose();
+    _commentController.dispose();
     super.dispose();
   }
 
@@ -993,8 +1199,8 @@ class _ItemEditorDialogState extends State<_ItemEditorDialog> {
     Navigator.of(context).pop(
       ItemDraft(
         name: _nameController.text.trim(),
-        quantity: _normalizedOptionalText(_quantityController.text),
-        unit: _normalizedOptionalText(_unitController.text),
+        comment: _normalizedOptionalText(_commentController.text),
+        quantity: widget.initialItem?.quantity ?? 1,
         isChecked: _isChecked,
       ),
     );
@@ -1015,7 +1221,7 @@ class _ItemEditorDialogState extends State<_ItemEditorDialog> {
     final isEditing = widget.initialItem != null;
 
     return AlertDialog(
-      title: Text(isEditing ? 'Edit item' : 'Add item'),
+      title: Text(isEditing ? 'Edytuj produkt' : 'Dodaj produkt'),
       content: SingleChildScrollView(
         child: Form(
           key: _formKey,
@@ -1024,38 +1230,23 @@ class _ItemEditorDialogState extends State<_ItemEditorDialog> {
             children: [
               TextFormField(
                 controller: _nameController,
-                decoration: const InputDecoration(labelText: 'Name'),
+                decoration: const InputDecoration(labelText: 'Nazwa'),
                 textInputAction: TextInputAction.next,
                 validator: (value) {
                   final trimmed = value?.trim() ?? '';
 
                   if (trimmed.isEmpty) {
-                    return 'Name is required';
+                    return 'Nazwa jest wymagana';
                   }
 
                   return null;
                 },
               ),
               TextFormField(
-                controller: _quantityController,
-                decoration: const InputDecoration(labelText: 'Quantity'),
-                textInputAction: TextInputAction.next,
-              ),
-              TextFormField(
-                controller: _unitController,
-                decoration: const InputDecoration(labelText: 'Unit'),
+                controller: _commentController,
+                decoration: const InputDecoration(labelText: 'Komentarz'),
                 textInputAction: TextInputAction.done,
                 onFieldSubmitted: (_) => _submit(),
-              ),
-              SwitchListTile(
-                contentPadding: EdgeInsets.zero,
-                title: const Text('Checked'),
-                value: _isChecked,
-                onChanged: (value) {
-                  setState(() {
-                    _isChecked = value;
-                  });
-                },
               ),
             ],
           ),
@@ -1064,9 +1255,9 @@ class _ItemEditorDialogState extends State<_ItemEditorDialog> {
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
-          child: const Text('Cancel'),
+          child: const Text('Anuluj'),
         ),
-        FilledButton(onPressed: _submit, child: const Text('Save')),
+        FilledButton(onPressed: _submit, child: const Text('Zapisz')),
       ],
     );
   }
@@ -1120,7 +1311,7 @@ class _ListNameDialogState extends State<_ListNameDialog> {
         child: TextFormField(
           controller: _controller,
           autofocus: true,
-          decoration: const InputDecoration(labelText: 'List name'),
+          decoration: const InputDecoration(labelText: 'Nazwa listy'),
           maxLength: 100,
           textInputAction: TextInputAction.done,
           onFieldSubmitted: (_) => _submit(),
@@ -1128,11 +1319,11 @@ class _ListNameDialogState extends State<_ListNameDialog> {
             final trimmed = value?.trim() ?? '';
 
             if (trimmed.isEmpty) {
-              return 'List name is required';
+              return 'Nazwa listy jest wymagana';
             }
 
             if (trimmed.length > 100) {
-              return 'List name must be at most 100 characters';
+              return 'Nazwa listy może mieć maksymalnie 100 znaków';
             }
 
             return null;
@@ -1142,7 +1333,7 @@ class _ListNameDialogState extends State<_ListNameDialog> {
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
-          child: const Text('Cancel'),
+          child: const Text('Anuluj'),
         ),
         FilledButton(
           onPressed: _submit,

--- a/mobile/lib/features/lists/share_list_dialog.dart
+++ b/mobile/lib/features/lists/share_list_dialog.dart
@@ -198,7 +198,7 @@ class _ShareListDialogState extends State<_ShareListDialog> {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: const Text('Share list'),
+      title: const Text('Udostępnij listę'),
       content: SingleChildScrollView(
         child: Form(
           key: _formKey,
@@ -210,7 +210,7 @@ class _ShareListDialogState extends State<_ShareListDialog> {
                 controller: _emailController,
                 autofocus: true,
                 decoration: const InputDecoration(
-                  labelText: 'User email',
+                  labelText: 'Email użytkownika',
                   hintText: 'second-user@example.com',
                 ),
                 keyboardType: TextInputType.emailAddress,
@@ -220,13 +220,13 @@ class _ShareListDialogState extends State<_ShareListDialog> {
                   final trimmed = value?.trim() ?? '';
 
                   if (trimmed.isEmpty) {
-                    return 'Email is required';
+                    return 'Email jest wymagany';
                   }
 
                   final emailPattern = RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$');
 
                   if (!emailPattern.hasMatch(trimmed)) {
-                    return 'Enter a valid email address';
+                    return 'Wpisz poprawny adres email';
                   }
 
                   return null;
@@ -240,7 +240,7 @@ class _ShareListDialogState extends State<_ShareListDialog> {
                 )
               else if (_recentEmails.isNotEmpty) ...[
                 Text(
-                  'Recent emails',
+                  'Ostatnie adresy',
                   style: Theme.of(context).textTheme.labelLarge,
                 ),
                 const SizedBox(height: 8),
@@ -264,11 +264,11 @@ class _ShareListDialogState extends State<_ShareListDialog> {
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
-          child: const Text('Cancel'),
+          child: const Text('Anuluj'),
         ),
         FilledButton(
           onPressed: _submit,
-          child: const Text('Share'),
+          child: const Text('Udostępnij'),
         ),
       ],
     );

--- a/mobile/test/api_client_test.dart
+++ b/mobile/test/api_client_test.dart
@@ -75,8 +75,8 @@ void main() {
       'id': 'item_1',
       'listId': 'list_1',
       'name': 'Milk',
-      'quantity': '2',
-      'unit': 'l',
+      'quantity': 2,
+      'comment': '2%',
       'isChecked': true,
       'sortOrder': 3,
       'createdByUserId': 'user_1',
@@ -87,8 +87,8 @@ void main() {
     expect(item.id, 'item_1');
     expect(item.listId, 'list_1');
     expect(item.name, 'Milk');
-    expect(item.quantity, '2');
-    expect(item.unit, 'l');
+    expect(item.quantity, 2);
+    expect(item.comment, '2%');
     expect(item.isChecked, true);
     expect(item.sortOrder, 3);
     expect(item.createdByUserId, 'user_1');
@@ -100,8 +100,8 @@ void main() {
       id: 'item_1',
       listId: 'list_1',
       name: 'Bread',
-      quantity: null,
-      unit: 'pcs',
+      comment: 'Na tosty',
+      quantity: 1,
       isChecked: false,
       sortOrder: 1,
       createdByUserId: 'user_1',
@@ -111,8 +111,8 @@ void main() {
 
     expect(item.toDraft().toJson(), {
       'name': 'Bread',
-      'quantity': null,
-      'unit': 'pcs',
+      'comment': 'Na tosty',
+      'quantity': 1,
       'isChecked': false,
     });
   });
@@ -120,16 +120,16 @@ void main() {
   test('ItemDraft.copyWith keeps existing values by default', () {
     const draft = ItemDraft(
       name: 'Milk',
-      quantity: '1',
-      unit: 'l',
+      quantity: 1,
+      comment: 'Bez laktozy',
       isChecked: false,
     );
 
-    final updated = draft.copyWith(isChecked: true);
+    final updated = draft.copyWith(isChecked: true, quantity: 2);
 
     expect(updated.name, 'Milk');
-    expect(updated.quantity, '1');
-    expect(updated.unit, 'l');
+    expect(updated.quantity, 2);
+    expect(updated.comment, 'Bez laktozy');
     expect(updated.isChecked, true);
   });
 
@@ -275,7 +275,8 @@ void main() {
     expect(adapter.lastRequest?.data, isNull);
     expect(adapter.lastRequest?.contentType, isNull);
     expect(adapter.lastRequest?.headers[Headers.contentTypeHeader], isNull);
-    expect(adapter.lastRequest?.headers['Authorization'], 'Bearer session-token');
+    expect(
+        adapter.lastRequest?.headers['Authorization'], 'Bearer session-token');
   });
 
   test('ApiClient deleteItem sends no json content type or body', () async {
@@ -300,7 +301,8 @@ void main() {
     expect(adapter.lastRequest?.data, isNull);
     expect(adapter.lastRequest?.contentType, isNull);
     expect(adapter.lastRequest?.headers[Headers.contentTypeHeader], isNull);
-    expect(adapter.lastRequest?.headers['Authorization'], 'Bearer session-token');
+    expect(
+        adapter.lastRequest?.headers['Authorization'], 'Bearer session-token');
   });
 
   test('ApiClient archiveList sends no json content type or body', () async {
@@ -339,7 +341,8 @@ void main() {
     expect(adapter.lastRequest?.data, isNull);
     expect(adapter.lastRequest?.contentType, isNull);
     expect(adapter.lastRequest?.headers[Headers.contentTypeHeader], isNull);
-    expect(adapter.lastRequest?.headers['Authorization'], 'Bearer session-token');
+    expect(
+        adapter.lastRequest?.headers['Authorization'], 'Bearer session-token');
     expect(result.isArchived, true);
   });
 
@@ -379,7 +382,8 @@ void main() {
     expect(adapter.lastRequest?.data, isNull);
     expect(adapter.lastRequest?.contentType, isNull);
     expect(adapter.lastRequest?.headers[Headers.contentTypeHeader], isNull);
-    expect(adapter.lastRequest?.headers['Authorization'], 'Bearer session-token');
+    expect(
+        adapter.lastRequest?.headers['Authorization'], 'Bearer session-token');
     expect(result.isArchived, false);
   });
 

--- a/mobile/test/list_detail_page_test.dart
+++ b/mobile/test/list_detail_page_test.dart
@@ -38,24 +38,25 @@ void main() {
 
     await tester.tap(find.byIcon(Icons.add));
     await tester.pumpAndSettle();
-    await tester.enterText(find.widgetWithText(TextFormField, 'Name'), 'Bread');
-    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Nazwa'), 'Bread');
+    await tester.tap(find.widgetWithText(FilledButton, 'Zapisz'));
     await tester.pumpAndSettle();
 
-    expect(find.text('Bread'), findsOneWidget);
+    expect(find.text('Bread (1)'), findsOneWidget);
     expect(apiClient.createItemCalls, 1);
 
     await tester.tap(find.byIcon(Icons.refresh));
     await tester.pump();
 
-    expect(find.text('Bread'), findsOneWidget);
+    expect(find.text('Bread (1)'), findsOneWidget);
 
     createCompleter.complete(
       _item(id: 'item_bread', name: 'Bread', sortOrder: 2),
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Bread'), findsOneWidget);
+    expect(find.text('Bread (1)'), findsOneWidget);
     expect(find.byType(Checkbox), findsNWidgets(2));
   });
 
@@ -89,17 +90,17 @@ void main() {
 
     await tester.tap(find.byIcon(Icons.more_vert));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Share list'));
+    await tester.tap(find.text('Udostępnij listę'));
     await tester.pumpAndSettle();
     await tester.enterText(
-      find.widgetWithText(TextFormField, 'User email'),
+      find.widgetWithText(TextFormField, 'Email użytkownika'),
       'second-user@example.com',
     );
-    await tester.tap(find.widgetWithText(FilledButton, 'Share'));
+    await tester.tap(find.widgetWithText(FilledButton, 'Udostępnij'));
     await tester.pumpAndSettle();
 
     expect(apiClient.shareListCalls, 1);
-    expect(find.text('Shared with second-user@example.com.'), findsOneWidget);
+    expect(find.text('Udostępniono second-user@example.com.'), findsOneWidget);
     expect(
       await historyStore.readRecentEmails(),
       equals(const <String>['second-user@example.com']),
@@ -141,7 +142,7 @@ void main() {
 
     await tester.tap(find.byIcon(Icons.more_vert));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Archive list'));
+    await tester.tap(find.text('Archiwizuj listę'));
     await tester.pumpAndSettle();
 
     expect(apiClient.archiveListCalls, 1);
@@ -172,18 +173,18 @@ void main() {
 
     await tester.tap(find.byIcon(Icons.more_vert));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Share list'));
+    await tester.tap(find.text('Udostępnij listę'));
     await tester.pumpAndSettle();
     await tester.enterText(
-      find.widgetWithText(TextFormField, 'User email'),
+      find.widgetWithText(TextFormField, 'Email użytkownika'),
       'pending-user@example.com',
     );
-    await tester.tap(find.widgetWithText(FilledButton, 'Share'));
+    await tester.tap(find.widgetWithText(FilledButton, 'Udostępnij'));
     await tester.pumpAndSettle();
 
     expect(
       find.text(
-        'List shared with pending-user@example.com. It will appear after they sign in.',
+        'Udostępniono pending-user@example.com. Lista pojawi się po zalogowaniu.',
       ),
       findsOneWidget,
     );
@@ -208,18 +209,18 @@ void main() {
 
     await tester.tap(find.byIcon(Icons.more_vert));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Rename list'));
+    await tester.tap(find.text('Zmień nazwę listy'));
     await tester.pumpAndSettle();
     await tester.enterText(
-      find.widgetWithText(TextFormField, 'List name'),
+      find.widgetWithText(TextFormField, 'Nazwa listy'),
       'Weekend groceries',
     );
-    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    await tester.tap(find.widgetWithText(FilledButton, 'Zapisz'));
     await tester.pumpAndSettle();
 
     expect(apiClient.updateListCalls, 1);
     expect(find.text('Weekend groceries'), findsWidgets);
-    expect(find.text('Renamed to Weekend groceries.'), findsOneWidget);
+    expect(find.text('Zmieniono nazwę na Weekend groceries.'), findsOneWidget);
   });
 
   testWidgets('rejects an empty rename before calling the backend', (
@@ -234,13 +235,14 @@ void main() {
 
     await tester.tap(find.byIcon(Icons.more_vert));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Rename list'));
+    await tester.tap(find.text('Zmień nazwę listy'));
     await tester.pumpAndSettle();
-    await tester.enterText(find.widgetWithText(TextFormField, 'List name'), '');
-    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Nazwa listy'), '');
+    await tester.tap(find.widgetWithText(FilledButton, 'Zapisz'));
     await tester.pump();
 
-    expect(find.text('List name is required'), findsOneWidget);
+    expect(find.text('Nazwa listy jest wymagana'), findsOneWidget);
     expect(apiClient.updateListCalls, 0);
   });
 
@@ -259,21 +261,22 @@ void main() {
     await tester.tap(find.byIcon(Icons.edit_outlined));
     await tester.pumpAndSettle();
     await tester.enterText(
-      find.widgetWithText(TextFormField, 'Name'),
+      find.widgetWithText(TextFormField, 'Nazwa'),
       'Oat milk',
     );
-    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    await tester.tap(find.widgetWithText(FilledButton, 'Zapisz'));
     await tester.pumpAndSettle();
 
-    expect(find.text('Oat milk'), findsOneWidget);
-    expect(find.text('Milk'), findsNothing);
+    expect(find.textContaining('Oat milk'), findsOneWidget);
+    expect(find.textContaining('Milk (2)'), findsNothing);
 
     updateCompleter.completeError(const ApiException('Save failed'));
     await tester.pumpAndSettle();
 
-    expect(find.text('Milk'), findsOneWidget);
-    expect(find.text('Oat milk'), findsNothing);
-    expect(find.text('Could not save item: Save failed'), findsOneWidget);
+    expect(find.textContaining('Milk (2)'), findsOneWidget);
+    expect(find.textContaining('Oat milk'), findsNothing);
+    expect(find.text('Nie udało się zapisać produktu: Save failed'),
+        findsOneWidget);
   });
 
   testWidgets('keeps loaded items visible when refresh fails', (tester) async {
@@ -294,9 +297,9 @@ void main() {
     await tester.tap(find.byIcon(Icons.refresh));
     await tester.pumpAndSettle();
 
-    expect(find.text('Milk'), findsOneWidget);
+    expect(find.textContaining('Milk (2)'), findsOneWidget);
     expect(
-      find.textContaining('Could not refresh items: Refresh failed'),
+      find.textContaining('Nie udało się odświeżyć produktów: Refresh failed'),
       findsOneWidget,
     );
   });
@@ -322,7 +325,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(tester.widget<Checkbox>(find.byType(Checkbox)).value, isFalse);
-    expect(find.text('Could not update item: Update failed'), findsOneWidget);
+    expect(find.text('Nie udało się zaktualizować produktu: Update failed'),
+        findsOneWidget);
   });
 
   testWidgets('reverts an optimistic delete when the backend rejects it', (
@@ -339,16 +343,17 @@ void main() {
 
     await tester.tap(find.byIcon(Icons.delete_outline));
     await tester.pumpAndSettle();
-    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    await tester.tap(find.widgetWithText(FilledButton, 'Usuń'));
     await tester.pump();
 
-    expect(find.text('Milk'), findsNothing);
+    expect(find.textContaining('Milk (2)'), findsNothing);
 
     deleteCompleter.completeError(const ApiException('Delete failed'));
     await tester.pumpAndSettle();
 
-    expect(find.text('Milk'), findsOneWidget);
-    expect(find.text('Could not delete item: Delete failed'), findsOneWidget);
+    expect(find.textContaining('Milk (2)'), findsOneWidget);
+    expect(find.text('Nie udało się usunąć produktu: Delete failed'),
+        findsOneWidget);
   });
 
   testWidgets('marks the list as mutated as soon as a toggle starts',
@@ -380,8 +385,8 @@ void main() {
       _item(
         id: 'item_1',
         name: 'Milk',
-        quantity: '2',
-        unit: 'l',
+        quantity: 2,
+        comment: '2%',
         isChecked: true,
         sortOrder: 1,
       ),
@@ -412,16 +417,16 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      tester.getTopLeft(find.text('Milk')).dy,
-      lessThan(tester.getTopLeft(find.text('Bread')).dy),
+      tester.getTopLeft(find.text('Milk (1)')).dy,
+      lessThan(tester.getTopLeft(find.text('Bread (1)')).dy),
     );
 
     await tester.tap(find.byType(Checkbox).first);
     await tester.pump();
 
     expect(
-      tester.getTopLeft(find.text('Bread')).dy,
-      lessThan(tester.getTopLeft(find.text('Milk')).dy),
+      tester.getTopLeft(find.text('Bread (1)')).dy,
+      lessThan(tester.getTopLeft(find.text('Milk (1)')).dy),
     );
 
     updateCompleter.complete(
@@ -434,21 +439,61 @@ void main() {
     );
     await tester.pumpAndSettle();
   });
+
+  testWidgets('shows suggestions and adds them to the list', (tester) async {
+    final apiClient = _FakeApiClient(
+      items: <ShoppingListItem>[],
+      suggestions: <ItemSuggestion>[
+        ItemSuggestion(
+          id: 'suggestion_milk',
+          name: 'Milk',
+          comment: '2%',
+          usageCount: 12,
+          lastUsedAt: DateTime.utc(2026, 4, 10, 12),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(buildSubject(apiClient));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Sugestie'), findsOneWidget);
+    await tester.tap(find.widgetWithText(ActionChip, 'Milk • 2%'));
+    await tester.pumpAndSettle();
+
+    expect(apiClient.createItemCalls, 1);
+    expect(find.text('Milk (1)'), findsOneWidget);
+  });
+
+  testWidgets('increments item quantity with plus button', (tester) async {
+    final apiClient = _FakeApiClient(
+      items: <ShoppingListItem>[_milkItem],
+    );
+
+    await tester.pumpWidget(buildSubject(apiClient));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Zwiększ ilość'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Milk (3)'), findsOneWidget);
+    expect(apiClient.lastUpdatedDraft?.quantity, 3);
+  });
 }
 
 final ShoppingListItem _milkItem = _item(
   id: 'item_1',
   name: 'Milk',
-  quantity: '2',
-  unit: 'l',
+  quantity: 2,
+  comment: '2%',
   sortOrder: 1,
 );
 
 ShoppingListItem _item({
   required String id,
   required String name,
-  String? quantity,
-  String? unit,
+  int quantity = 1,
+  String? comment,
   bool isChecked = false,
   int sortOrder = 0,
 }) {
@@ -456,8 +501,8 @@ ShoppingListItem _item({
     id: id,
     listId: 'list_1',
     name: name,
+    comment: comment,
     quantity: quantity,
-    unit: unit,
     isChecked: isChecked,
     sortOrder: sortOrder,
     createdByUserId: 'user_1',
@@ -468,7 +513,8 @@ ShoppingListItem _item({
 
 class _FakeApiClient extends ApiClient {
   _FakeApiClient({
-    required this.items,
+    required List<ShoppingListItem> items,
+    List<ItemSuggestion> suggestions = const <ItemSuggestion>[],
     this.createItemHandler,
     this.updateItemHandler,
     this.updateListHandler,
@@ -476,9 +522,12 @@ class _FakeApiClient extends ApiClient {
     this.deleteItemHandler,
     this.fetchItemsHandler,
     this.shareListHandler,
-  }) : super(baseUrl: 'http://localhost:3000', accessToken: 'token');
+  })  : items = List<ShoppingListItem>.from(items),
+        suggestions = List<ItemSuggestion>.from(suggestions),
+        super(baseUrl: 'http://localhost:3000', accessToken: 'token');
 
   final List<ShoppingListItem> items;
+  final List<ItemSuggestion> suggestions;
   final Future<List<ShoppingListItem>> Function(int callCount)?
       fetchItemsHandler;
   final Future<ShoppingListItem> Function(String listId, ItemDraft draft)?
@@ -500,6 +549,7 @@ class _FakeApiClient extends ApiClient {
   int shareListCalls = 0;
   int updateListCalls = 0;
   int archiveListCalls = 0;
+  ItemDraft? lastUpdatedDraft;
 
   @override
   Future<List<ShoppingListItem>> fetchItems(String listId) async {
@@ -514,6 +564,11 @@ class _FakeApiClient extends ApiClient {
   }
 
   @override
+  Future<List<ItemSuggestion>> fetchItemSuggestions() async {
+    return List<ItemSuggestion>.from(suggestions);
+  }
+
+  @override
   Future<ShoppingListItem> createItem(String listId, ItemDraft draft) async {
     createItemCalls += 1;
 
@@ -524,8 +579,8 @@ class _FakeApiClient extends ApiClient {
     final createdItem = _item(
       id: 'created_${items.length + 1}',
       name: draft.name,
+      comment: draft.comment,
       quantity: draft.quantity,
-      unit: draft.unit,
       isChecked: draft.isChecked,
       sortOrder: items.length,
     );
@@ -539,6 +594,8 @@ class _FakeApiClient extends ApiClient {
     String itemId,
     ItemDraft draft,
   ) async {
+    lastUpdatedDraft = draft;
+
     if (updateItemHandler != null) {
       return updateItemHandler!(listId, itemId, draft);
     }
@@ -546,8 +603,8 @@ class _FakeApiClient extends ApiClient {
     final index = items.indexWhere((item) => item.id == itemId);
     final updatedItem = items[index].copyWith(
       name: draft.name,
+      comment: draft.comment,
       quantity: draft.quantity,
-      unit: draft.unit,
       isChecked: draft.isChecked,
     );
     items[index] = updatedItem;

--- a/mobile/test/list_overview_page_test.dart
+++ b/mobile/test/list_overview_page_test.dart
@@ -54,7 +54,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 100));
 
     expect(find.text('Weekly groceries'), findsWidgets);
-    expect(find.text('No items yet. Add the first one.'), findsOneWidget);
+    expect(find.text('Brak produktów. Dodaj pierwszy.'), findsOneWidget);
   });
 
   testWidgets('shows an empty state when the user has no visible lists', (
@@ -164,10 +164,10 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 200));
     await tester.enterText(
-      find.widgetWithText(TextFormField, 'User email'),
+      find.widgetWithText(TextFormField, 'Email użytkownika'),
       'second-user@example.com',
     );
-    await tester.tap(find.widgetWithText(FilledButton, 'Share'));
+    await tester.tap(find.widgetWithText(FilledButton, 'Udostępnij'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 300));
 
@@ -218,10 +218,10 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 200));
     await tester.enterText(
-      find.widgetWithText(TextFormField, 'User email'),
+      find.widgetWithText(TextFormField, 'Email użytkownika'),
       'Second-User@example.com ',
     );
-    await tester.tap(find.widgetWithText(FilledButton, 'Share'));
+    await tester.tap(find.widgetWithText(FilledButton, 'Udostępnij'));
     await tester.pumpAndSettle();
 
     expect(
@@ -233,14 +233,14 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 200));
 
-    expect(find.text('Recent emails'), findsOneWidget);
+    expect(find.text('Ostatnie adresy'), findsOneWidget);
     expect(find.text('second-user@example.com'), findsNWidgets(2));
 
     await tester.tap(find.byType(ActionChip));
     await tester.pump();
 
     final field = tester.widget<TextFormField>(
-      find.widgetWithText(TextFormField, 'User email'),
+      find.widgetWithText(TextFormField, 'Email użytkownika'),
     );
     expect(field.controller?.text, 'second-user@example.com');
   });
@@ -260,7 +260,7 @@ class _FakeApiClient extends ApiClient {
   final List<ShoppingListSummary> lists;
   final Object? listsError;
   final Future<List<ShoppingListSummary>> Function(int callCount)?
-  fetchListsHandler;
+      fetchListsHandler;
   final Future<ShareListResult> Function(String listId, String email)?
       shareListHandler;
 


### PR DESCRIPTION
Summary

- replaces the old item model with `name + comment + quantity:int` and adds a Prisma migration that preserves existing data
- adds server-side item suggestions ranked by usage count and exposes them through `GET /items/suggestions`
- simplifies the list detail UI in Polish, adds suggestion chips, and adds inline `+/-` quantity controls

What changed

- backend now stores item comments and integer quantities instead of the old quantity/unit text pair
- item suggestion usage is updated when an item is created or when its quantity increases
- the item editor now only asks for product name and optional comment
- tapping a suggestion adds the product directly, and tapping it again increments quantity on the existing list item

Testing

- `npm run prisma:generate`
- `node --import tsx --test src/modules/items/routes.test.ts`
- `npm run build`
- `flutter test test/api_client_test.dart test/list_detail_page_test.dart test/list_overview_page_test.dart --reporter compact`
- `flutter analyze lib/core/network/api_client.dart lib/features/lists/list_detail_page.dart lib/features/lists/share_list_dialog.dart test/api_client_test.dart test/list_detail_page_test.dart test/list_overview_page_test.dart`

Notes

- deploy requires applying the new Prisma migration before the updated mobile build talks to production
- I intentionally did not stage the local generated Flutter platform files under `mobile/ios` and `mobile/android`
