### PR TITLE
Fix Zod body parsing types for list dates

### DIFF
--- a/backend/src/modules/lists/routes.ts
+++ b/backend/src/modules/lists/routes.ts
@@ -270,7 +270,10 @@ function toInvitationResponse(invitation: Pick<InvitationRecord, 'id' | 'listId'
   };
 }
 
-function parseBody<T>(schema: z.ZodType<T>, body: unknown) {
+function parseBody<TSchema extends z.ZodTypeAny>(
+  schema: TSchema,
+  body: unknown,
+): z.output<TSchema> | null {
   const result = schema.safeParse(body);
 
   if (!result.success) {


### PR DESCRIPTION
Summary

- fixes the `parseBody` helper typing so Zod schemas that transform input strings into `Date` values compile correctly
- unblocks the backend CI/build failure introduced by the optional `plannedFor` field on shopping lists

Testing

- `npm run build`
- `node --import tsx --test src/modules/lists/routes.test.ts`