### PR TITLE
Backend: add account phone number support for WhatsApp contact linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 **/.DS_Store
 **/.flutter-plugins-dependencies
 infra/qnap.backend.env
+.worktrees/

--- a/backend/prisma/migrations/20260421200000_add_user_phone_number/migration.sql
+++ b/backend/prisma/migrations/20260421200000_add_user_phone_number/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "users"
+ADD COLUMN "phone_number" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -11,6 +11,7 @@ model User {
   id                String           @id @default(cuid())
   email             String           @unique
   displayName       String           @map("display_name")
+  phoneNumber       String?          @map("phone_number")
   createdAt         DateTime         @default(now()) @map("created_at")
   updatedAt         DateTime         @updatedAt @map("updated_at")
   ownedLists        ShoppingList[]

--- a/backend/src/lib/types.ts
+++ b/backend/src/lib/types.ts
@@ -2,6 +2,7 @@ export type UserRecord = {
   id: string;
   email: string;
   displayName: string;
+  phoneNumber: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -63,6 +64,16 @@ export type AuthPrisma = {
       data: {
         email: string;
         displayName: string;
+        phoneNumber?: string | null;
+      };
+    }): Promise<UserRecord>;
+    update(args: {
+      where: {
+        id: string;
+      };
+      data: {
+        displayName?: string;
+        phoneNumber?: string | null;
       };
     }): Promise<UserRecord>;
   };

--- a/backend/src/modules/auth/routes.test.ts
+++ b/backend/src/modules/auth/routes.test.ts
@@ -11,6 +11,7 @@ type TestUser = {
   id: string;
   email: string;
   displayName: string;
+  phoneNumber: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -55,6 +56,7 @@ function buildUser(overrides: Partial<TestUser> = {}): TestUser {
     id: 'user_1',
     email: 'test@example.com',
     displayName: 'Test User',
+    phoneNumber: null,
     createdAt: new Date('2026-03-29T10:00:00.000Z'),
     updatedAt: new Date('2026-03-29T10:00:00.000Z'),
     ...overrides
@@ -86,16 +88,45 @@ async function buildApp(options: {
 
         return [...users.values()].find((user) => user.email === where.email) ?? null;
       },
-      create: async ({ data }: { data: { email: string; displayName: string } }) => {
+      create: async ({
+        data
+      }: {
+        data: { email: string; displayName: string; phoneNumber?: string | null };
+      }) => {
         const user = buildUser({
           id: `user_${users.size + 1}`,
           email: data.email,
           displayName: data.displayName,
+          phoneNumber: data.phoneNumber ?? null,
           createdAt: now,
           updatedAt: now
         });
 
         users.set(user.id, user);
+        return user;
+      },
+      update: async ({
+        where,
+        data
+      }: {
+        where: { id: string };
+        data: { displayName?: string; phoneNumber?: string | null };
+      }) => {
+        const user = users.get(where.id);
+
+        if (!user) {
+          throw new Error('User not found');
+        }
+
+        if (data.displayName !== undefined) {
+          user.displayName = data.displayName;
+        }
+
+        if (data.phoneNumber !== undefined) {
+          user.phoneNumber = data.phoneNumber;
+        }
+
+        user.updatedAt = now;
         return user;
       }
     },
@@ -396,7 +427,9 @@ test('POST /auth/verify-code rejects an invalid code and increments attempts', a
 });
 
 test('GET /auth/me returns the authenticated user for a valid session', async () => {
-  const user = buildUser();
+  const user = buildUser({
+    phoneNumber: '+48123123123'
+  });
   const rawToken = 'valid-session-token';
   const { app } = await buildApp({
     users: [user],
@@ -426,6 +459,128 @@ test('GET /auth/me returns the authenticated user for a valid session', async ()
 
     assert.equal(response.statusCode, 200);
     assert.equal(response.json().user.email, user.email);
+    assert.equal(response.json().user.phoneNumber, user.phoneNumber);
+  } finally {
+    await app.close();
+  }
+});
+
+test('PATCH /auth/me saves a normalized phone number for the authenticated user', async () => {
+  const user = buildUser();
+  const rawToken = 'valid-session-token';
+  const { app, users } = await buildApp({
+    users: [user],
+    sessions: [
+      {
+        id: 'session_1',
+        userId: user.id,
+        tokenHash: hashSecret(rawToken),
+        deviceLabel: null,
+        lastUsedAt: new Date('2026-04-05T20:00:00.000Z'),
+        expiresAt: new Date('2026-07-05T20:00:00.000Z'),
+        revokedAt: null,
+        createdAt: new Date('2026-04-05T20:00:00.000Z'),
+        updatedAt: new Date('2026-04-05T20:00:00.000Z')
+      }
+    ]
+  });
+
+  try {
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/auth/me',
+      headers: {
+        authorization: `Bearer ${rawToken}`
+      },
+      payload: {
+        phoneNumber: ' +48 123 123 123 '
+      }
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.json().user.phoneNumber, '+48123123123');
+    assert.equal(users.get(user.id)?.phoneNumber, '+48123123123');
+  } finally {
+    await app.close();
+  }
+});
+
+test('PATCH /auth/me clears the saved phone number when null is provided', async () => {
+  const user = buildUser({
+    phoneNumber: '+48123123123'
+  });
+  const rawToken = 'valid-session-token';
+  const { app, users } = await buildApp({
+    users: [user],
+    sessions: [
+      {
+        id: 'session_1',
+        userId: user.id,
+        tokenHash: hashSecret(rawToken),
+        deviceLabel: null,
+        lastUsedAt: new Date('2026-04-05T20:00:00.000Z'),
+        expiresAt: new Date('2026-07-05T20:00:00.000Z'),
+        revokedAt: null,
+        createdAt: new Date('2026-04-05T20:00:00.000Z'),
+        updatedAt: new Date('2026-04-05T20:00:00.000Z')
+      }
+    ]
+  });
+
+  try {
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/auth/me',
+      headers: {
+        authorization: `Bearer ${rawToken}`
+      },
+      payload: {
+        phoneNumber: null
+      }
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.json().user.phoneNumber, null);
+    assert.equal(users.get(user.id)?.phoneNumber, null);
+  } finally {
+    await app.close();
+  }
+});
+
+test('PATCH /auth/me rejects an invalid phone number', async () => {
+  const user = buildUser();
+  const rawToken = 'valid-session-token';
+  const { app, users } = await buildApp({
+    users: [user],
+    sessions: [
+      {
+        id: 'session_1',
+        userId: user.id,
+        tokenHash: hashSecret(rawToken),
+        deviceLabel: null,
+        lastUsedAt: new Date('2026-04-05T20:00:00.000Z'),
+        expiresAt: new Date('2026-07-05T20:00:00.000Z'),
+        revokedAt: null,
+        createdAt: new Date('2026-04-05T20:00:00.000Z'),
+        updatedAt: new Date('2026-04-05T20:00:00.000Z')
+      }
+    ]
+  });
+
+  try {
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/auth/me',
+      headers: {
+        authorization: `Bearer ${rawToken}`
+      },
+      payload: {
+        phoneNumber: 'abc-123'
+      }
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(users.get(user.id)?.phoneNumber, null);
   } finally {
     await app.close();
   }

--- a/backend/src/modules/auth/routes.ts
+++ b/backend/src/modules/auth/routes.ts
@@ -15,7 +15,8 @@ import {
   getCodeExpiryDate,
   getSessionExpiryDate,
   hashSecret,
-  normalizeEmail
+  normalizeEmail,
+  normalizePhoneNumber
 } from './session.js';
 
 type AuthRoutesDeps = {
@@ -35,6 +36,10 @@ const verifyCodeBodySchema = z.object({
   email: emailSchema,
   code: z.string().trim().regex(/^\d{6}$/),
   displayName: z.string().trim().min(2).max(50).optional()
+});
+
+const updateProfileBodySchema = z.object({
+  phoneNumber: z.union([z.string().trim().min(1).max(32), z.null()])
 });
 
 const defaultDeps: AuthRoutesDeps = {
@@ -257,6 +262,40 @@ export function createAuthRoutes(deps: AuthRoutesDeps = defaultDeps): FastifyPlu
 
       return {
         user: toUserResponse(user)
+      };
+    });
+
+    app.patch('/auth/me', async (request, reply) => {
+      const user = await authenticateRequest(deps.prisma, request, reply);
+
+      if (!user) {
+        return;
+      }
+
+      const body = parseBody(updateProfileBodySchema, request.body);
+
+      if (!body) {
+        return reply.badRequest('Invalid request body');
+      }
+
+      const phoneNumber =
+        body.phoneNumber === null ? null : normalizePhoneNumber(body.phoneNumber);
+
+      if (body.phoneNumber !== null && phoneNumber === null) {
+        return reply.badRequest('Invalid phone number');
+      }
+
+      const updatedUser = await deps.prisma.user.update({
+        where: {
+          id: user.id
+        },
+        data: {
+          phoneNumber
+        }
+      });
+
+      return {
+        user: toUserResponse(updatedUser)
       };
     });
   };

--- a/backend/src/modules/auth/session.ts
+++ b/backend/src/modules/auth/session.ts
@@ -13,6 +13,32 @@ export function normalizeEmail(email: string) {
   return email.trim().toLowerCase();
 }
 
+export function normalizePhoneNumber(phoneNumber: string) {
+  const trimmed = phoneNumber.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  let normalized = trimmed.replace(/[\s()-]/g, '');
+
+  if (normalized.startsWith('00')) {
+    normalized = `+${normalized.slice(2)}`;
+  }
+
+  if (!/^\+?\d+$/.test(normalized)) {
+    return null;
+  }
+
+  const digits = normalized.startsWith('+') ? normalized.slice(1) : normalized;
+
+  if (digits.length < 8 || digits.length > 15 || digits.startsWith('0')) {
+    return null;
+  }
+
+  return `+${digits}`;
+}
+
 export function hashSecret(value: string) {
   return crypto.createHash('sha256').update(value).digest('hex');
 }

--- a/backend/src/modules/auth/utils.ts
+++ b/backend/src/modules/auth/utils.ts
@@ -5,6 +5,7 @@ export function toUserResponse(user: UserRecord) {
     id: user.id,
     email: user.email,
     displayName: user.displayName,
+    phoneNumber: user.phoneNumber,
     createdAt: user.createdAt,
     updatedAt: user.updatedAt
   };

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,6 +6,7 @@
 - `POST /auth/verify-code`
 - `POST /auth/logout`
 - `GET /auth/me`
+- `PATCH /auth/me`
 
 ### Auth contract summary
 
@@ -60,6 +61,7 @@ Response:
     "id": "user_id",
     "email": "test@example.com",
     "displayName": "Piotr",
+    "phoneNumber": null,
     "createdAt": "2026-03-29T10:00:00.000Z",
     "updatedAt": "2026-03-29T10:00:00.000Z"
   }
@@ -107,11 +109,48 @@ Response:
     "id": "user_id",
     "email": "test@example.com",
     "displayName": "Piotr",
+    "phoneNumber": null,
     "createdAt": "2026-03-29T10:00:00.000Z",
     "updatedAt": "2026-03-29T10:00:00.000Z"
   }
 }
 ```
+
+### `PATCH /auth/me`
+
+Headers:
+
+```http
+Authorization: Bearer trusted-session-token
+```
+
+Request body:
+
+```json
+{
+  "phoneNumber": "+48123123123"
+}
+```
+
+Response:
+
+```json
+{
+  "user": {
+    "id": "user_id",
+    "email": "test@example.com",
+    "displayName": "Piotr",
+    "phoneNumber": "+48123123123",
+    "createdAt": "2026-03-29T10:00:00.000Z",
+    "updatedAt": "2026-03-29T10:00:00.000Z"
+  }
+}
+```
+
+Notes:
+- send `null` as `phoneNumber` to clear the saved number
+- the backend normalizes accepted values to `+<countrycode><number>` form
+- invalid phone numbers should return `400`
 
 ## Lists
 


### PR DESCRIPTION
## Summary

- adds nullable `phoneNumber` support to the backend user profile schema and auth responses
- adds `PATCH /auth/me` so the authenticated user can save or clear their phone number for future WhatsApp linking
- documents the new auth profile contract and covers normalization/validation with backend tests

## Progress

- [x] implementation
- [x] unit tests
- [x] integration-style route tests
- [x] docs updates

## Plan

- [x] add backend persistence for a nullable user phone number
- [x] expose the field in auth/profile responses
- [x] add authenticated profile update support for phone number save/clear flows
- [x] add tests for normalization, clearing, and invalid input
- [x] update API notes for the mobile Settings follow-up

## GitHub workflow

- Closes #60
- Parent #59
- Project status: `In Progress`

## Validation

- `npm run build`
- `DATABASE_URL=postgresql://test:test@127.0.0.1:5432/test JWT_SECRET=test-secret node --import tsx --test src/modules/auth/routes.test.ts`

## Notes

- phone numbers are normalized to `+<countrycode><number>` form before persistence
- this PR intentionally stops at the backend contract; member eligibility and mobile Settings/WhatsApp UI land in follow-up issues #61, #62, and #63
