### PR TITLE
Backend: expose shared-member WhatsApp eligibility in list contracts

### DIFF
--- a/backend/src/modules/lists/routes.test.ts
+++ b/backend/src/modules/lists/routes.test.ts
@@ -11,6 +11,7 @@ type TestUser = {
   id: string;
   email: string;
   displayName: string;
+  phoneNumber: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -64,6 +65,7 @@ function buildUser(overrides: Partial<TestUser> = {}): TestUser {
     id: 'user_1',
     email: 'test@example.com',
     displayName: 'Test User',
+    phoneNumber: null,
     createdAt: new Date('2026-03-29T10:00:00.000Z'),
     updatedAt: new Date('2026-03-29T10:00:00.000Z'),
     ...overrides
@@ -278,6 +280,23 @@ async function buildApp(
     listMember: {
       findUnique: async ({ where }: { where: { listId_userId: { listId: string; userId: string } } }) =>
         membersByKey.get(`${where.listId_userId.listId}:${where.listId_userId.userId}`) ?? null,
+      findMany: async ({
+        where,
+        include
+      }: {
+        where: { listId: string };
+        include?: { user?: boolean };
+      }) =>
+        [...membersByKey.values()]
+          .filter((member) => member.listId === where.listId)
+          .map((member) =>
+            include?.user
+              ? {
+                  ...member,
+                  user: userById.get(member.userId) ?? undefined
+                }
+              : member
+          ),
       create: async ({
         data,
         include
@@ -322,6 +341,18 @@ async function buildApp(
     listInvitation: {
       findUnique: async ({ where }: { where: { listId_email: { listId: string; email: string } } }) =>
         invitations.find((item) => item.listId === where.listId_email.listId && item.email === where.listId_email.email) ?? null,
+      findMany: async ({ where }: { where: { listId: string; claimedAt?: null } }) =>
+        invitations.filter((item) => {
+          if (item.listId !== where.listId) {
+            return false;
+          }
+
+          if (where.claimedAt === null && item.claimedAt !== null) {
+            return false;
+          }
+
+          return true;
+        }),
       create: async ({ data }: { data: { listId: string; email: string; role: 'owner' | 'editor'; invitedByUserId: string } }) => {
         const invitation: TestInvitation = {
           id: `invite_${invitations.length + 1}`,
@@ -564,7 +595,12 @@ test('GET /lists rejects missing token', async () => {
 
 test('POST /lists/:listId/members adds an editor by email for the owner', async () => {
   const owner = buildUser();
-  const invitedUser = buildUser({ id: 'user_2', email: 'editor@example.com', displayName: 'Editor' });
+  const invitedUser = buildUser({
+    id: 'user_2',
+    email: 'editor@example.com',
+    displayName: 'Editor',
+    phoneNumber: '+48123123123'
+  });
   const list = buildList({ id: 'list_1', ownerUserId: owner.id, memberIds: new Set([owner.id]) });
   const { rawToken, session } = buildSessionToken(owner.id);
   const { app } = await buildApp(
@@ -586,7 +622,127 @@ test('POST /lists/:listId/members adds an editor by email for the owner', async 
 
     assert.equal(response.statusCode, 201);
     assert.equal(response.json().member.userId, invitedUser.id);
+    assert.equal(response.json().member.user.phoneNumber, invitedUser.phoneNumber);
+    assert.equal(response.json().member.user.whatsappEligible, true);
     assert.equal(list.memberIds.has(invitedUser.id), true);
+  } finally {
+    await app.close();
+  }
+});
+
+test('GET /lists/:listId returns owner-only sharing metadata for active members and pending invitations', async () => {
+  const owner = buildUser();
+  const editor = buildUser({
+    id: 'user_2',
+    email: 'editor@example.com',
+    displayName: 'Editor',
+    phoneNumber: '+48123123123'
+  });
+  const noPhoneEditor = buildUser({
+    id: 'user_3',
+    email: 'nophone@example.com',
+    displayName: 'No Phone',
+    phoneNumber: null
+  });
+  const list = buildList({
+    id: 'list_1',
+    ownerUserId: owner.id,
+    memberIds: new Set([owner.id, editor.id, noPhoneEditor.id])
+  });
+  const pendingInvitation: TestInvitation = {
+    id: 'invite_1',
+    listId: list.id,
+    email: 'pending@example.com',
+    role: 'editor',
+    invitedByUserId: owner.id,
+    claimedByUserId: null,
+    claimedAt: null,
+    createdAt: new Date('2026-03-30T10:00:00.000Z'),
+    updatedAt: new Date('2026-03-30T10:00:00.000Z')
+  };
+  const { rawToken, session } = buildSessionToken(owner.id);
+  const { app } = await buildApp(
+    new Map([
+      [owner.id, owner],
+      [editor.id, editor],
+      [noPhoneEditor.id, noPhoneEditor]
+    ]),
+    new Map([[list.id, list]]),
+    [session],
+    [pendingInvitation]
+  );
+
+  try {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/lists/${list.id}`,
+      headers: { authorization: `Bearer ${rawToken}` }
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.json().sharing.memberContacts.length, 2);
+    assert.deepEqual(
+      response.json().sharing.memberContacts.map((member: { user: { email: string } }) => member.user.email).sort(),
+      ['editor@example.com', 'nophone@example.com']
+    );
+    const whatsappEligibleByEmail = Object.fromEntries(
+      response.json().sharing.memberContacts.map((member: { user: { email: string; whatsappEligible: boolean; phoneNumber: string | null } }) => [
+        member.user.email,
+        {
+          whatsappEligible: member.user.whatsappEligible,
+          phoneNumber: member.user.phoneNumber
+        }
+      ])
+    );
+    assert.deepEqual(whatsappEligibleByEmail, {
+      'editor@example.com': {
+        whatsappEligible: true,
+        phoneNumber: '+48123123123'
+      },
+      'nophone@example.com': {
+        whatsappEligible: false,
+        phoneNumber: null
+      }
+    });
+    assert.equal(response.json().sharing.pendingInvitations.length, 1);
+    assert.equal(response.json().sharing.pendingInvitations[0].email, 'pending@example.com');
+  } finally {
+    await app.close();
+  }
+});
+
+test('GET /lists/:listId does not expose sharing metadata to non-owner members', async () => {
+  const owner = buildUser();
+  const editor = buildUser({
+    id: 'user_2',
+    email: 'editor@example.com',
+    displayName: 'Editor',
+    phoneNumber: '+48123123123'
+  });
+  const list = buildList({
+    id: 'list_1',
+    ownerUserId: owner.id,
+    memberIds: new Set([owner.id, editor.id])
+  });
+  const { rawToken, session } = buildSessionToken(editor.id);
+  const { app } = await buildApp(
+    new Map([
+      [owner.id, owner],
+      [editor.id, editor]
+    ]),
+    new Map([[list.id, list]]),
+    [session]
+  );
+
+  try {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/lists/${list.id}`,
+      headers: { authorization: `Bearer ${rawToken}` }
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal('sharing' in response.json(), false);
   } finally {
     await app.close();
   }

--- a/backend/src/modules/lists/routes.ts
+++ b/backend/src/modules/lists/routes.ts
@@ -16,6 +16,11 @@ type ListResponse = {
   updatedAt: Date;
 };
 
+type ListDetailResponse = {
+  list: ListResponse;
+  sharing?: SharingResponse;
+};
+
 type MemberResponse = {
   id: string;
   listId: string;
@@ -27,6 +32,8 @@ type MemberResponse = {
     id: string;
     email: string;
     displayName: string;
+    phoneNumber: string | null;
+    whatsappEligible: boolean;
   };
 };
 
@@ -38,6 +45,11 @@ type InvitationResponse = {
   status: 'pending';
   createdAt: Date;
   updatedAt: Date;
+};
+
+type SharingResponse = {
+  memberContacts: MemberResponse[];
+  pendingInvitations: InvitationResponse[];
 };
 
 type ListRecord = {
@@ -133,7 +145,15 @@ type ListMemberRepository = {
     include?: {
       user?: boolean;
     };
-  }): Promise<MemberRecord & { user?: Pick<UserRecord, 'id' | 'email' | 'displayName'> }>;
+  }): Promise<MemberRecord & { user?: Pick<UserRecord, 'id' | 'email' | 'displayName' | 'phoneNumber'> }>;
+  findMany(args: {
+    where: {
+      listId: string;
+    };
+    include?: {
+      user?: boolean;
+    };
+  }): Promise<Array<MemberRecord & { user?: Pick<UserRecord, 'id' | 'email' | 'displayName' | 'phoneNumber'> }>>;
   delete(args: {
     where: {
       listId_userId: {
@@ -190,6 +210,12 @@ type InvitationRepository = {
       invitedByUserId: string;
     };
   }): Promise<InvitationRecord>;
+  findMany(args: {
+    where: {
+      listId: string;
+      claimedAt?: null;
+    };
+  }): Promise<InvitationRecord[]>;
 };
 
 type ListRoutesDeps = {
@@ -240,7 +266,7 @@ function toListResponse(
 
 function toMemberResponse(
   member: Pick<MemberRecord, 'id' | 'listId' | 'userId' | 'role' | 'createdAt' | 'updatedAt'> & {
-    user: Pick<UserRecord, 'id' | 'email' | 'displayName'>;
+    user: Pick<UserRecord, 'id' | 'email' | 'displayName' | 'phoneNumber'>;
   }
 ): MemberResponse {
   return {
@@ -253,7 +279,9 @@ function toMemberResponse(
     user: {
       id: member.user.id,
       email: member.user.email,
-      displayName: member.user.displayName
+      displayName: member.user.displayName,
+      phoneNumber: member.user.phoneNumber,
+      whatsappEligible: member.user.phoneNumber != null
     }
   };
 }
@@ -321,6 +349,47 @@ function parseIncludeArchived(value: unknown) {
   return value === true || value === 'true' || value === '1' || value === 1;
 }
 
+async function buildOwnerSharingResponse(
+  deps: ListRoutesDeps,
+  listId: string,
+  ownerUserId: string,
+): Promise<SharingResponse> {
+  const [members, invitations] = await Promise.all([
+    deps.prisma.listMember.findMany({
+      where: {
+        listId
+      },
+      include: {
+        user: true
+      }
+    }),
+    deps.prisma.listInvitation.findMany({
+      where: {
+        listId,
+        claimedAt: null
+      }
+    })
+  ]);
+
+  const memberContacts = members
+    .filter((member) => member.userId !== ownerUserId)
+    .map((member) => {
+      if (!member.user) {
+        throw new Error('Expected included user on list member lookup');
+      }
+
+      return toMemberResponse({
+        ...member,
+        user: member.user
+      });
+    });
+
+  return {
+    memberContacts,
+    pendingInvitations: invitations.map(toInvitationResponse)
+  };
+}
+
 export function createListRoutes(deps: ListRoutesDeps = defaultDeps): FastifyPluginAsync {
   return async (app) => {
     app.get('/lists', async (request, reply) => {
@@ -386,7 +455,7 @@ export function createListRoutes(deps: ListRoutesDeps = defaultDeps): FastifyPlu
       });
     });
 
-    app.get('/lists/:listId', async (request, reply) => {
+    app.get('/lists/:listId', async (request, reply): Promise<ListDetailResponse | void> => {
       const user = await authenticateRequest(deps.prisma, request, reply);
 
       if (!user) {
@@ -400,9 +469,15 @@ export function createListRoutes(deps: ListRoutesDeps = defaultDeps): FastifyPlu
         return reply.notFound('List not found');
       }
 
-      return {
+      const response: ListDetailResponse = {
         list: toListResponse(list)
       };
+
+      if (list.ownerUserId === user.id) {
+        response.sharing = await buildOwnerSharingResponse(deps, list.id, user.id);
+      }
+
+      return response;
     });
 
     app.patch('/lists/:listId', async (request, reply) => {

--- a/docs/api.md
+++ b/docs/api.md
@@ -234,9 +234,45 @@ Response:
     "archivedAt": null,
     "createdAt": "2026-03-29T10:00:00.000Z",
     "updatedAt": "2026-03-29T10:00:00.000Z"
+  },
+  "sharing": {
+    "memberContacts": [
+      {
+        "id": "member_id",
+        "listId": "list_id",
+        "userId": "user_id",
+        "role": "editor",
+        "createdAt": "2026-03-29T10:00:00.000Z",
+        "updatedAt": "2026-03-29T10:00:00.000Z",
+        "user": {
+          "id": "user_id",
+          "email": "second-user@example.com",
+          "displayName": "Second User",
+          "phoneNumber": "+48123123123",
+          "whatsappEligible": true
+        }
+      }
+    ],
+    "pendingInvitations": [
+      {
+        "id": "invite_id",
+        "listId": "list_id",
+        "email": "pending@example.com",
+        "role": "editor",
+        "status": "pending",
+        "createdAt": "2026-03-29T10:00:00.000Z",
+        "updatedAt": "2026-03-29T10:00:00.000Z"
+      }
+    ]
   }
 }
 ```
+
+Notes:
+- the owner receives a `sharing` block with active member contact metadata and pending invitations
+- non-owner members still receive only the `list` object
+- `user.phoneNumber` is only exposed inside the owner-facing sharing metadata
+- `user.whatsappEligible` is `true` when the active member has a saved linked phone number
 
 ### `PATCH /lists/:listId`
 
@@ -354,7 +390,9 @@ Response:
     "user": {
       "id": "user_id",
       "email": "second-user@example.com",
-      "displayName": "Second User"
+      "displayName": "Second User",
+      "phoneNumber": "+48123123123",
+      "whatsappEligible": true
     }
   }
 }
@@ -364,6 +402,7 @@ Notes:
 - if the email already belongs to an active user, the backend creates the membership immediately
 - otherwise the backend creates a pending email share that will be auto-claimed the next time that email signs in
 - duplicate active memberships or duplicate pending email shares should return `409 Conflict`
+- immediate member responses now include `phoneNumber` and `whatsappEligible` for owner-facing WhatsApp handoff flows
 
 Alternative response for a pending invitation:
 


### PR DESCRIPTION
## Summary

- adds owner-only `sharing` metadata to `GET /lists/:listId` for active members and pending invitations
- includes `phoneNumber` and `whatsappEligible` in immediate member-share responses when the invited email already belongs to an active user
- documents the contract and covers owner vs non-owner visibility with backend route tests

## Progress

- [x] implementation
- [x] unit tests
- [x] integration-style route tests
- [x] docs updates

## GitHub workflow

- Closes #61
- Parent #59
- Project status: `In Progress`

## Validation

- `npm run build`
- `DATABASE_URL=postgresql://test:test@127.0.0.1:5432/test JWT_SECRET=test-secret node --import tsx --test src/modules/lists/routes.test.ts`

## Notes

- only the list owner receives phone-linked sharing metadata on list detail reads
- non-owner members still receive the existing list detail shape without sharing contacts
- this backend contract is designed to unblock the mobile notify button in #63 without leaking phone numbers to editors
