### PR TITLE
Mobile: add WhatsApp notify action with disabled state for unlinked contacts

### DIFF
--- a/mobile/lib/core/network/api_client.dart
+++ b/mobile/lib/core/network/api_client.dart
@@ -9,6 +9,23 @@ String normalizeBaseUrl(String baseUrl) {
   return baseUrl.trim().replaceAll(RegExp(r'/$'), '');
 }
 
+Map<String, dynamic> _readResponseObject(
+  Map<String, dynamic>? payload,
+  String key,
+) {
+  final value = payload?[key];
+
+  if (value is Map<String, dynamic>) {
+    return value;
+  }
+
+  if (value is Map) {
+    return Map<String, dynamic>.from(value);
+  }
+
+  throw ApiException('Brakuje pola $key w odpowiedzi API.');
+}
+
 class ApiClient {
   ApiClient({
     required String baseUrl,
@@ -121,6 +138,17 @@ class ApiClient {
               .cast<Map<String, dynamic>>();
 
       return items.map(ShoppingListSummary.fromJson).toList(growable: false);
+    });
+  }
+
+  Future<ShoppingListDetail> fetchListDetail(String listId) {
+    return _guard(() async {
+      final response = await _dio.get<Map<String, dynamic>>(
+        '/lists/$listId',
+        options: _authOptions(),
+      );
+
+      return ShoppingListDetail.fromJson(response.data ?? const {});
     });
   }
 
@@ -458,6 +486,52 @@ class ShoppingListSummary {
   }
 }
 
+class ShoppingListDetail {
+  const ShoppingListDetail({
+    required this.list,
+    this.sharing,
+  });
+
+  final ShoppingListSummary list;
+  final ListSharingMetadata? sharing;
+
+  factory ShoppingListDetail.fromJson(Map<String, dynamic> json) {
+    return ShoppingListDetail(
+      list: ShoppingListSummary.fromJson(_readResponseObject(json, 'list')),
+      sharing: json['sharing'] == null
+          ? null
+          : ListSharingMetadata.fromJson(_readResponseObject(json, 'sharing')),
+    );
+  }
+}
+
+class ListSharingMetadata {
+  const ListSharingMetadata({
+    required this.memberContacts,
+    required this.pendingInvitations,
+  });
+
+  final List<ListMember> memberContacts;
+  final List<PendingListInvitation> pendingInvitations;
+
+  factory ListSharingMetadata.fromJson(Map<String, dynamic> json) {
+    final memberContacts =
+        (json['memberContacts'] as List<dynamic>? ?? const <dynamic>[])
+            .cast<Map<String, dynamic>>();
+    final pendingInvitations =
+        (json['pendingInvitations'] as List<dynamic>? ?? const <dynamic>[])
+            .cast<Map<String, dynamic>>();
+
+    return ListSharingMetadata(
+      memberContacts:
+          memberContacts.map(ListMember.fromJson).toList(growable: false),
+      pendingInvitations: pendingInvitations
+          .map(PendingListInvitation.fromJson)
+          .toList(growable: false),
+    );
+  }
+}
+
 class ItemDraft {
   const ItemDraft({
     required this.name,
@@ -616,17 +690,23 @@ class ListMemberUser {
     required this.id,
     required this.email,
     required this.displayName,
+    required this.phoneNumber,
+    required this.whatsappEligible,
   });
 
   final String id;
   final String email;
   final String displayName;
+  final String? phoneNumber;
+  final bool whatsappEligible;
 
   factory ListMemberUser.fromJson(Map<String, dynamic> json) {
     return ListMemberUser(
       id: json['id'] as String,
       email: json['email'] as String,
       displayName: json['displayName'] as String,
+      phoneNumber: json['phoneNumber'] as String?,
+      whatsappEligible: json['whatsappEligible'] as bool? ?? false,
     );
   }
 }

--- a/mobile/lib/features/lists/list_detail_page.dart
+++ b/mobile/lib/features/lists/list_detail_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../../core/models/item_icon.dart';
 import '../../core/network/api_client.dart';
@@ -48,6 +49,7 @@ class ListDetailPage extends StatefulWidget {
     this.canManageList = false,
     this.onUnauthorized,
     this.shareEmailHistoryStore,
+    this.urlLauncher,
     super.key,
   });
 
@@ -59,6 +61,7 @@ class ListDetailPage extends StatefulWidget {
   final bool canManageList;
   final Future<void> Function()? onUnauthorized;
   final ShareEmailHistoryStore? shareEmailHistoryStore;
+  final Future<bool> Function(Uri uri)? urlLauncher;
 
   @override
   State<ListDetailPage> createState() => _ListDetailPageState();
@@ -73,11 +76,14 @@ class _ListDetailPageState extends State<ListDetailPage> {
 
   late String _listName;
   DateTime? _plannedFor;
+  ListSharingMetadata? _sharing;
   late final ShareEmailHistoryStore _shareEmailHistoryStore;
   bool _isLoading = true;
   bool _isSharing = false;
+  bool _isLaunchingWhatsApp = false;
   bool _didMutateList = false;
   String? _errorMessage;
+  _WhatsAppDraft? _lastWhatsAppDraft;
   int _temporaryItemCounter = 0;
   Timer? _refreshTimer;
 
@@ -90,10 +96,12 @@ class _ListDetailPageState extends State<ListDetailPage> {
     _plannedFor = widget.plannedFor;
     _reloadItems();
     _reloadSuggestions();
+    _reloadListDetail(silent: true);
     _refreshTimer = Timer.periodic(const Duration(seconds: 15), (_) {
       if (mounted) {
         _reloadItems(silent: true);
         _reloadSuggestions(silent: true);
+        _reloadListDetail(silent: true);
       }
     });
   }
@@ -185,6 +193,41 @@ class _ListDetailPageState extends State<ListDetailPage> {
     }
   }
 
+  Future<void> _reloadListDetail({bool silent = false}) async {
+    if (!widget.canManageList) {
+      return;
+    }
+
+    try {
+      final detail = await widget.apiClient.fetchListDetail(widget.listId);
+
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _listName = detail.list.name;
+        _plannedFor = detail.list.plannedFor;
+        _sharing = detail.sharing;
+      });
+    } on ApiException catch (error) {
+      if (error.isUnauthorized && widget.onUnauthorized != null) {
+        await widget.onUnauthorized!();
+        return;
+      }
+
+      if (!silent && mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'Nie udało się pobrać danych udostępniania: ${error.message}',
+            ),
+          ),
+        );
+      }
+    }
+  }
+
   Future<void> _createItemFromDraft(ItemDraft draft) async {
     final temporaryId = _nextTemporaryItemId();
     final optimisticItem = _buildOptimisticItem(
@@ -195,6 +238,7 @@ class _ListDetailPageState extends State<ListDetailPage> {
 
     setState(() {
       _didMutateList = true;
+      _lastWhatsAppDraft = _WhatsAppDraft.added(_describeDraft(draft));
       _pendingItemIds.add(temporaryId);
       _pendingItemMutations[temporaryId] = _PendingItemMutation.create(
         optimisticItem: optimisticItem,
@@ -291,6 +335,8 @@ class _ListDetailPageState extends State<ListDetailPage> {
 
     setState(() {
       _didMutateList = true;
+      _lastWhatsAppDraft =
+          _WhatsAppDraft.updated(_describeItem(optimisticItem));
       _pendingItemIds.add(item.id);
       _pendingItemMutations[item.id] = _PendingItemMutation.update(
         previousItem: previousItem,
@@ -368,6 +414,9 @@ class _ListDetailPageState extends State<ListDetailPage> {
 
     setState(() {
       _didMutateList = true;
+      _lastWhatsAppDraft = _WhatsAppDraft.updated(
+        _describeItem(previousItem.copyWith(isChecked: checked)),
+      );
       _pendingItemIds.add(item.id);
       _pendingItemMutations[item.id] = _PendingItemMutation.update(
         previousItem: previousItem,
@@ -459,6 +508,8 @@ class _ListDetailPageState extends State<ListDetailPage> {
 
     setState(() {
       _didMutateList = true;
+      _lastWhatsAppDraft =
+          _WhatsAppDraft.updated(_describeItem(optimisticItem));
       _pendingItemIds.add(item.id);
       _pendingItemMutations[item.id] = _PendingItemMutation.update(
         previousItem: previousItem,
@@ -594,6 +645,7 @@ class _ListDetailPageState extends State<ListDetailPage> {
 
     setState(() {
       _didMutateList = true;
+      _lastWhatsAppDraft = _WhatsAppDraft.removed(_describeItem(previousItem));
       _pendingItemIds.add(item.id);
       _pendingItemMutations[item.id] = _PendingItemMutation.delete(
         previousItem: previousItem,
@@ -671,6 +723,8 @@ class _ListDetailPageState extends State<ListDetailPage> {
           ? 'Udostępniono ${result.member!.user.email}.'
           : 'Udostępniono ${result.invitation!.email}. Lista pojawi się po zalogowaniu.';
 
+      unawaited(_reloadListDetail(silent: true));
+
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(SnackBar(content: Text(message)));
@@ -734,6 +788,7 @@ class _ListDetailPageState extends State<ListDetailPage> {
         _didMutateList = true;
         _listName = updatedList.name;
         _plannedFor = updatedList.plannedFor;
+        _lastWhatsAppDraft = _WhatsAppDraft.updatedList(updatedList.name);
       });
 
       ScaffoldMessenger.of(context).showSnackBar(
@@ -790,6 +845,16 @@ class _ListDetailPageState extends State<ListDetailPage> {
           ),
           actions: [
             IconButton(
+              onPressed: _canNotifyOnWhatsApp ? _notifyOnWhatsApp : null,
+              icon: _isLaunchingWhatsApp
+                  ? const SizedBox.square(
+                      dimension: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.chat_outlined),
+              tooltip: 'Powiadom przez WhatsApp',
+            ),
+            IconButton(
               onPressed: () => _reloadItems(),
               icon: const Icon(Icons.refresh),
               tooltip: 'Odśwież',
@@ -825,6 +890,7 @@ class _ListDetailPageState extends State<ListDetailPage> {
           onRefresh: () async {
             await _reloadItems(silent: true);
             await _reloadSuggestions(silent: true);
+            await _reloadListDetail(silent: true);
           },
           child: _buildBody(context),
         ),
@@ -989,6 +1055,113 @@ class _ListDetailPageState extends State<ListDetailPage> {
     return left.createdAt.compareTo(right.createdAt);
   }
 
+  bool get _canNotifyOnWhatsApp =>
+      !_isLaunchingWhatsApp && _selectedWhatsAppContact != null;
+
+  ListMember? get _selectedWhatsAppContact {
+    for (final member in _sharing?.memberContacts ?? const <ListMember>[]) {
+      if (member.user.whatsappEligible &&
+          (member.user.phoneNumber?.trim().isNotEmpty ?? false)) {
+        return member;
+      }
+    }
+
+    return null;
+  }
+
+  String _describeDraft(ItemDraft draft) {
+    return _buildItemDescription(
+      name: draft.name,
+      quantity: draft.quantity,
+      comment: draft.comment,
+    );
+  }
+
+  String _describeItem(ShoppingListItem item) {
+    return _buildItemDescription(
+      name: item.name,
+      quantity: item.quantity,
+      comment: item.comment,
+    );
+  }
+
+  String _buildItemDescription({
+    required String name,
+    required int quantity,
+    required String? comment,
+  }) {
+    final quantityLabel = quantity > 1 ? '$name ($quantity)' : name;
+    final trimmedComment = comment?.trim();
+
+    if (trimmedComment == null || trimmedComment.isEmpty) {
+      return quantityLabel;
+    }
+
+    return '$quantityLabel, $trimmedComment';
+  }
+
+  Future<void> _notifyOnWhatsApp() async {
+    final member = _selectedWhatsAppContact;
+    if (member == null) {
+      return;
+    }
+
+    final normalizedPhoneNumber = member.user.phoneNumber?.replaceAll(
+      RegExp(r'\D'),
+      '',
+    );
+    if (normalizedPhoneNumber == null || normalizedPhoneNumber.isEmpty) {
+      return;
+    }
+
+    final message = (_lastWhatsAppDraft ?? _WhatsAppDraft.generic()).toMessage(
+      listName: _listName,
+      recipientName: member.user.displayName,
+    );
+    final uri = Uri(
+      scheme: 'https',
+      host: 'wa.me',
+      path: '/$normalizedPhoneNumber',
+      queryParameters: <String, String>{'text': message},
+    );
+
+    setState(() {
+      _isLaunchingWhatsApp = true;
+    });
+
+    try {
+      final launch = widget.urlLauncher ??
+          (uri) => launchUrl(uri, mode: LaunchMode.externalApplication);
+      final didLaunch = await launch(uri);
+
+      if (!didLaunch && mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Nie udało się otworzyć WhatsApp. Sprawdź, czy aplikacja jest zainstalowana.',
+            ),
+          ),
+        );
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Nie udało się otworzyć WhatsApp. Sprawdź, czy aplikacja jest zainstalowana.',
+            ),
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLaunchingWhatsApp = false;
+        });
+      }
+    }
+  }
+
   int _nextSortOrder() {
     if (_items.isEmpty) {
       return 0;
@@ -1146,6 +1319,47 @@ class _ListDetailPageState extends State<ListDetailPage> {
 }
 
 enum _ListAction { share, rename }
+
+enum _WhatsAppDraftKind { generic, added, updated, removed, updatedList }
+
+class _WhatsAppDraft {
+  const _WhatsAppDraft._(this.kind, this.subject);
+
+  const _WhatsAppDraft.generic() : this._(_WhatsAppDraftKind.generic, null);
+
+  const _WhatsAppDraft.added(String subject)
+      : this._(_WhatsAppDraftKind.added, subject);
+
+  const _WhatsAppDraft.updated(String subject)
+      : this._(_WhatsAppDraftKind.updated, subject);
+
+  const _WhatsAppDraft.removed(String subject)
+      : this._(_WhatsAppDraftKind.removed, subject);
+
+  const _WhatsAppDraft.updatedList(String listName)
+      : this._(_WhatsAppDraftKind.updatedList, listName);
+
+  final _WhatsAppDraftKind kind;
+  final String? subject;
+
+  String toMessage({
+    required String listName,
+    required String recipientName,
+  }) {
+    switch (kind) {
+      case _WhatsAppDraftKind.added:
+        return 'Hej $recipientName, dodalem do listy "$listName": $subject. Zerknij prosze.';
+      case _WhatsAppDraftKind.updated:
+        return 'Hej $recipientName, zaktualizowalem na liscie "$listName": $subject. Zerknij prosze.';
+      case _WhatsAppDraftKind.removed:
+        return 'Hej $recipientName, usunalem z listy "$listName": $subject. Zerknij prosze.';
+      case _WhatsAppDraftKind.updatedList:
+        return 'Hej $recipientName, zaktualizowalem szczegoly listy "$subject". Zerknij prosze.';
+      case _WhatsAppDraftKind.generic:
+        return 'Hej $recipientName, dodalem wazna aktualizacje do listy "$listName". Zerknij prosze.';
+    }
+  }
+}
 
 enum _PendingItemMutationType { create, update, delete }
 

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -437,6 +437,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.29"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   vector_math:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   dio: ^5.7.0
   flutter_secure_storage: ^9.2.2
+  url_launcher: ^6.3.1
 
 dev_dependencies:
   flutter_test:

--- a/mobile/test/api_client_test.dart
+++ b/mobile/test/api_client_test.dart
@@ -63,12 +63,16 @@ void main() {
       'user': {
         'id': 'user_2',
         'email': 'second-user@example.com',
-        'displayName': 'Second User'
+        'displayName': 'Second User',
+        'phoneNumber': '+48123123123',
+        'whatsappEligible': true,
       }
     });
 
     expect(member.user.email, 'second-user@example.com');
     expect(member.role, 'editor');
+    expect(member.user.phoneNumber, '+48123123123');
+    expect(member.user.whatsappEligible, true);
   });
 
   test('ShoppingListItem.fromJson parses API payloads', () {
@@ -500,6 +504,85 @@ void main() {
     expect(result.isInvitationPending, true);
     expect(result.invitation?.email, 'pending@example.com');
     expect(result.member, isNull);
+  });
+
+  test('ApiClient fetchListDetail parses sharing metadata', () async {
+    final adapter = _RecordingAdapter(
+      ResponseBody.fromString(
+        jsonEncode({
+          'list': {
+            'id': 'list_1',
+            'name': 'Weekly groceries',
+            'ownerUserId': 'user_1',
+            'plannedFor': '2026-04-15T00:00:00.000Z',
+            'isArchived': false,
+            'archivedAt': null,
+            'createdAt': '2026-04-10T12:00:00.000Z',
+            'updatedAt': '2026-04-11T12:00:00.000Z',
+          },
+          'sharing': {
+            'memberContacts': [
+              {
+                'id': 'member_1',
+                'listId': 'list_1',
+                'userId': 'user_2',
+                'role': 'editor',
+                'createdAt': '2026-04-10T12:00:00.000Z',
+                'updatedAt': '2026-04-11T12:00:00.000Z',
+                'user': {
+                  'id': 'user_2',
+                  'email': 'second-user@example.com',
+                  'displayName': 'Second User',
+                  'phoneNumber': '+48123123123',
+                  'whatsappEligible': true
+                }
+              }
+            ],
+            'pendingInvitations': [
+              {
+                'id': 'invite_1',
+                'listId': 'list_1',
+                'email': 'pending@example.com',
+                'role': 'editor',
+                'status': 'pending',
+                'createdAt': '2026-04-05T20:00:00.000Z',
+                'updatedAt': '2026-04-05T20:00:00.000Z'
+              }
+            ]
+          }
+        }),
+        200,
+        headers: {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+        },
+      ),
+    );
+    final dio = Dio();
+    dio.httpClientAdapter = adapter;
+
+    final client = ApiClient(
+      baseUrl: 'http://localhost:3000/',
+      accessToken: 'session-token',
+      dio: dio,
+    );
+
+    final detail = await client.fetchListDetail('list_1');
+
+    expect(adapter.lastRequest?.path, '/lists/list_1');
+    expect(adapter.lastRequest?.method, 'GET');
+    expect(
+        adapter.lastRequest?.headers['Authorization'], 'Bearer session-token');
+    expect(detail.list.name, 'Weekly groceries');
+    expect(detail.sharing?.memberContacts, hasLength(1));
+    expect(detail.sharing?.pendingInvitations, hasLength(1));
+    expect(
+      detail.sharing?.memberContacts.single.user.phoneNumber,
+      '+48123123123',
+    );
+    expect(
+      detail.sharing?.memberContacts.single.user.whatsappEligible,
+      true,
+    );
   });
 
   test('AuthSession and AuthUser parse API payloads', () {

--- a/mobile/test/list_detail_page_test.dart
+++ b/mobile/test/list_detail_page_test.dart
@@ -12,6 +12,7 @@ void main() {
     _FakeApiClient apiClient, {
     bool canManageList = false,
     ShareEmailHistoryStore? shareEmailHistoryStore,
+    Future<bool> Function(Uri uri)? urlLauncher,
   }) {
     return MaterialApp(
       home: ListDetailPage(
@@ -21,6 +22,7 @@ void main() {
         canManageList: canManageList,
         shareEmailHistoryStore:
             shareEmailHistoryStore ?? InMemoryShareEmailHistoryStore(),
+        urlLauncher: urlLauncher,
       ),
     );
   }
@@ -78,6 +80,8 @@ void main() {
               id: 'user_2',
               email: email,
               displayName: 'Second User',
+              phoneNumber: null,
+              whatsappEligible: false,
             ),
           ),
         );
@@ -469,6 +473,131 @@ void main() {
     expect(apiClient.lastUpdatedDraft?.quantity, 3);
   });
 
+  testWidgets('keeps WhatsApp notify disabled without a linked phone number', (
+    tester,
+  ) async {
+    final apiClient = _FakeApiClient(
+      items: <ShoppingListItem>[_milkItem],
+      listDetail: _listDetail(
+        sharing: ListSharingMetadata(
+          memberContacts: <ListMember>[
+            _member(
+              email: 'second-user@example.com',
+              displayName: 'Second User',
+              phoneNumber: null,
+              whatsappEligible: false,
+            ),
+          ],
+          pendingInvitations: const <PendingListInvitation>[],
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(buildSubject(apiClient, canManageList: true));
+    await tester.pumpAndSettle();
+
+    final notifyButton = tester.widget<IconButton>(
+      find.ancestor(
+        of: find.byIcon(Icons.chat_outlined),
+        matching: find.byType(IconButton),
+      ),
+    );
+    expect(notifyButton.onPressed, isNull);
+  });
+
+  testWidgets('launches WhatsApp with a prefilled last-change message', (
+    tester,
+  ) async {
+    final launchedUris = <Uri>[];
+    final apiClient = _FakeApiClient(
+      items: <ShoppingListItem>[_milkItem],
+      listDetail: _listDetail(
+        sharing: ListSharingMetadata(
+          memberContacts: <ListMember>[
+            _member(
+              email: 'second-user@example.com',
+              displayName: 'Second User',
+              phoneNumber: '+48 123 123 123',
+              whatsappEligible: true,
+            ),
+          ],
+          pendingInvitations: const <PendingListInvitation>[],
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(
+      buildSubject(
+        apiClient,
+        canManageList: true,
+        urlLauncher: (uri) async {
+          launchedUris.add(uri);
+          return true;
+        },
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Nazwa'),
+      'Bread',
+    );
+    await tester.tap(find.widgetWithText(FilledButton, 'Zapisz'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Powiadom przez WhatsApp'));
+    await tester.pumpAndSettle();
+
+    expect(launchedUris, hasLength(1));
+    expect(launchedUris.single.host, 'wa.me');
+    expect(launchedUris.single.path, '/48123123123');
+    final message = launchedUris.single.queryParameters['text'];
+    expect(message, isNotNull);
+    expect(message, contains('Weekly groceries'));
+    expect(message, contains('Bread'));
+    expect(message, contains('Second User'));
+  });
+
+  testWidgets('shows feedback when WhatsApp cannot be opened', (tester) async {
+    final apiClient = _FakeApiClient(
+      items: <ShoppingListItem>[_milkItem],
+      listDetail: _listDetail(
+        sharing: ListSharingMetadata(
+          memberContacts: <ListMember>[
+            _member(
+              email: 'second-user@example.com',
+              displayName: 'Second User',
+              phoneNumber: '+48123123123',
+              whatsappEligible: true,
+            ),
+          ],
+          pendingInvitations: const <PendingListInvitation>[],
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(
+      buildSubject(
+        apiClient,
+        canManageList: true,
+        urlLauncher: (_) async => false,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Powiadom przez WhatsApp'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(
+        'Nie udało się otworzyć WhatsApp. Sprawdź, czy aplikacja jest zainstalowana.',
+      ),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('changes an item icon from the edit dialog', (tester) async {
     final apiClient = _FakeApiClient(
       items: <ShoppingListItem>[_milkItem],
@@ -546,6 +675,7 @@ class _FakeApiClient extends ApiClient {
   _FakeApiClient({
     required List<ShoppingListItem> items,
     List<ItemSuggestion> suggestions = const <ItemSuggestion>[],
+    this.listDetail,
     this.createItemHandler,
     this.updateItemHandler,
     this.updateListHandler,
@@ -559,6 +689,7 @@ class _FakeApiClient extends ApiClient {
 
   final List<ShoppingListItem> items;
   final List<ItemSuggestion> suggestions;
+  final ShoppingListDetail? listDetail;
   final Future<List<ShoppingListItem>> Function(int callCount)?
       fetchItemsHandler;
   final Future<ShoppingListItem> Function(String listId, ItemDraft draft)?
@@ -601,6 +732,14 @@ class _FakeApiClient extends ApiClient {
   @override
   Future<List<ItemSuggestion>> fetchItemSuggestions() async {
     return List<ItemSuggestion>.from(suggestions);
+  }
+
+  @override
+  Future<ShoppingListDetail> fetchListDetail(String listId) async {
+    return listDetail ??
+        _listDetail(
+          name: 'Weekly groceries',
+        );
   }
 
   @override
@@ -738,10 +877,53 @@ class _FakeApiClient extends ApiClient {
           id: 'user_$shareListCalls',
           email: email,
           displayName: 'Shared User',
+          phoneNumber: null,
+          whatsappEligible: false,
         ),
       ),
     );
   }
+}
+
+ShoppingListDetail _listDetail({
+  String name = 'Weekly groceries',
+  DateTime? plannedFor,
+  ListSharingMetadata? sharing,
+}) {
+  return ShoppingListDetail(
+    list: ShoppingListSummary(
+      id: 'list_1',
+      name: name,
+      plannedFor: plannedFor,
+      ownerUserId: 'user_1',
+      createdAt: DateTime.utc(2026, 3, 31, 8),
+      updatedAt: DateTime.utc(2026, 4, 1, 12),
+    ),
+    sharing: sharing,
+  );
+}
+
+ListMember _member({
+  required String email,
+  required String displayName,
+  required String? phoneNumber,
+  required bool whatsappEligible,
+}) {
+  return ListMember(
+    id: 'member_${email.hashCode}',
+    listId: 'list_1',
+    userId: 'user_${email.hashCode}',
+    role: 'member',
+    createdAt: DateTime.utc(2026, 4, 1, 11),
+    updatedAt: DateTime.utc(2026, 4, 1, 11),
+    user: ListMemberUser(
+      id: 'user_${email.hashCode}',
+      email: email,
+      displayName: displayName,
+      phoneNumber: phoneNumber,
+      whatsappEligible: whatsappEligible,
+    ),
+  );
 }
 
 class _OpenListHarness extends StatelessWidget {


### PR DESCRIPTION
## Summary

- adds owner-facing WhatsApp notify support to the list-detail screen
- fetches owner-only sharing metadata from `GET /lists/:listId` and keeps the action disabled when no eligible linked phone number exists
- launches WhatsApp with a prefilled message and covers launch/disabled-state behavior with tests

## Progress

- [x] implementation
- [x] widget tests
- [x] API client tests

## GitHub workflow

- Closes #63
- Parent #59
- Project status: `In Progress`

## Validation

- `flutter pub get`
- `flutter test test/api_client_test.dart test/list_detail_page_test.dart`

## Notes

- this PR depends on the backend contract from #61
- it intentionally does not change the Settings/auth phone-number management flow from #62
