### PR TITLE
Mobile: add phone-number management to Settings

### DIFF
--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -123,6 +123,7 @@ class _AppBootstrapperState extends State<_AppBootstrapper> {
           return AppHomePage(
             session: state.session!,
             authRepository: _authRepository,
+            onUpdatePhoneNumber: _sessionController.updatePhoneNumber,
             onLogout: _sessionController.logout,
             onResetLocalData: _sessionController.resetLocalData,
             themeMode: widget.themeMode,

--- a/mobile/lib/core/network/api_client.dart
+++ b/mobile/lib/core/network/api_client.dart
@@ -10,35 +10,27 @@ String normalizeBaseUrl(String baseUrl) {
 }
 
 class ApiClient {
-  ApiClient({
-    required String baseUrl,
-    String accessToken = '',
-    Dio? dio,
-  })  : baseUrl = normalizeBaseUrl(baseUrl),
-        accessToken = accessToken.trim(),
-        _dio = dio ??
-            Dio(
-              BaseOptions(
-                baseUrl: normalizeBaseUrl(baseUrl),
-                responseType: ResponseType.json,
-              ),
-            );
+  ApiClient({required String baseUrl, String accessToken = '', Dio? dio})
+    : baseUrl = normalizeBaseUrl(baseUrl),
+      accessToken = accessToken.trim(),
+      _dio =
+          dio ??
+          Dio(
+            BaseOptions(
+              baseUrl: normalizeBaseUrl(baseUrl),
+              responseType: ResponseType.json,
+            ),
+          );
 
   final String baseUrl;
   final String accessToken;
   final Dio _dio;
 
   ApiClient withAccessToken(String nextAccessToken) {
-    return ApiClient(
-      baseUrl: baseUrl,
-      accessToken: nextAccessToken,
-    );
+    return ApiClient(baseUrl: baseUrl, accessToken: nextAccessToken);
   }
 
-  Future<void> requestCode({
-    required String email,
-    String? displayName,
-  }) {
+  Future<void> requestCode({required String email, String? displayName}) {
     return _guard(() async {
       final response = await _dio.post<Map<String, dynamic>>(
         '/auth/request-code',
@@ -90,6 +82,18 @@ class ApiClient {
     });
   }
 
+  Future<AuthUser> updateCurrentUser({required String? phoneNumber}) {
+    return _guard(() async {
+      final response = await _dio.patch<Map<String, dynamic>>(
+        '/auth/me',
+        data: {'phoneNumber': phoneNumber?.trim()},
+        options: _authOptions(),
+      );
+
+      return AuthUser.fromJson(_readObject(response.data, 'user'));
+    });
+  }
+
   Future<void> logout() {
     return _guard(() async {
       final response = await _dio.post<Map<String, dynamic>>(
@@ -107,9 +111,7 @@ class ApiClient {
     });
   }
 
-  Future<List<ShoppingListSummary>> fetchLists({
-    bool includeArchived = false,
-  }) {
+  Future<List<ShoppingListSummary>> fetchLists({bool includeArchived = false}) {
     return _guard(() async {
       final response = await _dio.get<Map<String, dynamic>>(
         '/lists',
@@ -190,9 +192,7 @@ class ApiClient {
     return _guard(() async {
       final response = await _dio.post<Map<String, dynamic>>(
         '/lists/$listId/members',
-        data: {
-          'email': email.trim(),
-        },
+        data: {'email': email.trim()},
         options: _authOptions(),
       );
 
@@ -290,9 +290,7 @@ class ApiClient {
       return const <String, dynamic>{};
     }
 
-    return <String, dynamic>{
-      'Authorization': 'Bearer $accessToken',
-    };
+    return <String, dynamic>{'Authorization': 'Bearer $accessToken'};
   }
 
   Options _authOptions() {
@@ -326,10 +324,7 @@ class ApiClient {
     );
   }
 
-  static String _readString(
-    Map<String, dynamic>? payload,
-    String key,
-  ) {
+  static String _readString(Map<String, dynamic>? payload, String key) {
     final value = payload?[key];
 
     if (value is String) {
@@ -365,10 +360,7 @@ class ApiException implements Exception {
     if (data is Map<String, dynamic>) {
       final message = data['message'];
       if (message is String && message.trim().isNotEmpty) {
-        return ApiException(
-          message,
-          statusCode: error.response?.statusCode,
-        );
+        return ApiException(message, statusCode: error.response?.statusCode);
       }
     }
 
@@ -447,7 +439,8 @@ class ShoppingListSummary {
       plannedFor: json['plannedFor'] == null
           ? null
           : DateTime.parse(json['plannedFor'] as String),
-      isArchived: json['isArchived'] as bool? ??
+      isArchived:
+          json['isArchived'] as bool? ??
           ((json['archivedAt'] as String?) != null),
       archivedAt: json['archivedAt'] == null
           ? null
@@ -708,15 +701,12 @@ class PendingListInvitation {
 }
 
 class ShareListResult {
-  const ShareListResult._({
-    this.member,
-    this.invitation,
-  });
+  const ShareListResult._({this.member, this.invitation});
 
   const ShareListResult.member(ListMember member) : this._(member: member);
 
   const ShareListResult.invitation(PendingListInvitation invitation)
-      : this._(invitation: invitation);
+    : this._(invitation: invitation);
 
   final ListMember? member;
   final PendingListInvitation? invitation;

--- a/mobile/lib/features/auth/app_home_page.dart
+++ b/mobile/lib/features/auth/app_home_page.dart
@@ -6,6 +6,7 @@ import '../../core/network/api_client.dart';
 import '../../core/network/collection_sync.dart';
 import '../../core/theme/theme_mode_menu.dart';
 import 'auth_profile_store.dart';
+import 'auth_models.dart';
 import '../lists/archived_lists_page.dart';
 import '../lists/list_detail_page.dart';
 import 'auth_repository.dart';
@@ -16,6 +17,7 @@ class AppHomePage extends StatefulWidget {
   const AppHomePage({
     required this.session,
     required this.authRepository,
+    required this.onUpdatePhoneNumber,
     required this.onLogout,
     required this.onResetLocalData,
     required this.themeMode,
@@ -26,6 +28,7 @@ class AppHomePage extends StatefulWidget {
 
   final StoredAuthSession session;
   final AuthRepository authRepository;
+  final Future<AuthUser> Function(String? phoneNumber) onUpdatePhoneNumber;
   final Future<void> Function() onLogout;
   final Future<void> Function() onResetLocalData;
   final ThemeMode themeMode;
@@ -116,10 +119,8 @@ class _AppHomePageState extends State<AppHomePage> {
   Future<void> _createList() async {
     final draft = await showDialog<_ListDraft>(
       context: context,
-      builder: (context) => const _ListEditorDialog(
-        title: 'Nowa lista',
-        actionLabel: 'Dodaj',
-      ),
+      builder: (context) =>
+          const _ListEditorDialog(title: 'Nowa lista', actionLabel: 'Dodaj'),
     );
 
     if (draft == null) {
@@ -137,11 +138,7 @@ class _AppHomePageState extends State<AppHomePage> {
       }
 
       setState(() {
-        upsertById(
-          target: _lists,
-          value: createdList,
-          idOf: (list) => list.id,
-        );
+        upsertById(target: _lists, value: createdList, idOf: (list) => list.id);
       });
     });
   }
@@ -163,9 +160,9 @@ class _AppHomePageState extends State<AppHomePage> {
         return;
       }
 
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(error.message)),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(error.message)));
     } finally {
       if (mounted) {
         setState(() {
@@ -232,6 +229,8 @@ class _AppHomePageState extends State<AppHomePage> {
               Navigator.of(context).push(
                 MaterialPageRoute<void>(
                   builder: (context) => SettingsPage(
+                    currentUser: widget.session.session.user,
+                    onUpdatePhoneNumber: widget.onUpdatePhoneNumber,
                     savedProfile: widget.savedProfile,
                     onResetLocalData: widget.onResetLocalData,
                   ),
@@ -282,11 +281,7 @@ class _AppHomePageState extends State<AppHomePage> {
             else if (_lists.isEmpty)
               const Padding(
                 padding: EdgeInsets.only(top: 32),
-                child: Center(
-                  child: Text(
-                    'Brak list. Dodaj pierwszą.',
-                  ),
-                ),
+                child: Center(child: Text('Brak list. Dodaj pierwszą.')),
               )
             else
               ..._lists.map(
@@ -369,10 +364,7 @@ class _AppHomePageState extends State<AppHomePage> {
 }
 
 class _ListTitle extends StatelessWidget {
-  const _ListTitle({
-    required this.name,
-    required this.plannedFor,
-  });
+  const _ListTitle({required this.name, required this.plannedFor});
 
   final String name;
   final DateTime? plannedFor;
@@ -423,20 +415,14 @@ class _ListTitle extends StatelessWidget {
 }
 
 class _ListDraft {
-  const _ListDraft({
-    required this.name,
-    required this.plannedFor,
-  });
+  const _ListDraft({required this.name, required this.plannedFor});
 
   final String name;
   final DateTime? plannedFor;
 }
 
 class _ListEditorDialog extends StatefulWidget {
-  const _ListEditorDialog({
-    required this.title,
-    required this.actionLabel,
-  });
+  const _ListEditorDialog({required this.title, required this.actionLabel});
 
   final String title;
   final String actionLabel;
@@ -490,7 +476,9 @@ class _ListEditorDialogState extends State<_ListEditorDialog> {
               title: const Text('Dodaj datę do nazwy'),
               subtitle: _plannedFor == null
                   ? null
-                  : Text('Dzisiejsza data: ${_ListTitle._formatDate(_plannedFor!)}'),
+                  : Text(
+                      'Dzisiejsza data: ${_ListTitle._formatDate(_plannedFor!)}',
+                    ),
               value: _plannedFor != null,
               onChanged: (enabled) {
                 setState(() {

--- a/mobile/lib/features/auth/auth_models.dart
+++ b/mobile/lib/features/auth/auth_models.dart
@@ -1,24 +1,29 @@
 class AuthUser {
-  const AuthUser(
-      {required this.id,
-      required this.email,
-      required this.displayName,
-      required this.createdAt,
-      required this.updatedAt});
+  const AuthUser({
+    required this.id,
+    required this.email,
+    required this.displayName,
+    required this.phoneNumber,
+    required this.createdAt,
+    required this.updatedAt,
+  });
 
   final String id;
   final String email;
   final String displayName;
+  final String? phoneNumber;
   final DateTime createdAt;
   final DateTime updatedAt;
 
   factory AuthUser.fromJson(Map<String, dynamic> json) {
     return AuthUser(
-        id: json['id'] as String,
-        email: json['email'] as String,
-        displayName: json['displayName'] as String,
-        createdAt: DateTime.parse(json['createdAt'] as String),
-        updatedAt: DateTime.parse(json['updatedAt'] as String));
+      id: json['id'] as String,
+      email: json['email'] as String,
+      displayName: json['displayName'] as String,
+      phoneNumber: json['phoneNumber'] as String?,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+    );
   }
 
   Map<String, dynamic> toJson() {
@@ -26,17 +31,15 @@ class AuthUser {
       'id': id,
       'email': email,
       'displayName': displayName,
+      'phoneNumber': phoneNumber,
       'createdAt': createdAt.toIso8601String(),
-      'updatedAt': updatedAt.toIso8601String()
+      'updatedAt': updatedAt.toIso8601String(),
     };
   }
 }
 
 class AuthSession {
-  const AuthSession({
-    required this.sessionToken,
-    required this.user,
-  });
+  const AuthSession({required this.sessionToken, required this.user});
 
   final String sessionToken;
   final AuthUser user;

--- a/mobile/lib/features/auth/auth_repository.dart
+++ b/mobile/lib/features/auth/auth_repository.dart
@@ -10,10 +10,9 @@ class AuthRepository {
     required String email,
     String? displayName,
   }) {
-    return ApiClient(baseUrl: baseUrl).requestCode(
-      email: email.trim(),
-      displayName: displayName?.trim(),
-    );
+    return ApiClient(
+      baseUrl: baseUrl,
+    ).requestCode(email: email.trim(), displayName: displayName?.trim());
   }
 
   Future<AuthSession> verifyCode({
@@ -39,14 +38,19 @@ class AuthRepository {
     ).fetchCurrentUser();
   }
 
-  Future<void> logout({
+  Future<AuthUser> updatePhoneNumber({
     required String baseUrl,
     required String sessionToken,
+    required String? phoneNumber,
   }) {
     return ApiClient(
       baseUrl: baseUrl,
       accessToken: sessionToken,
-    ).logout();
+    ).updateCurrentUser(phoneNumber: phoneNumber);
+  }
+
+  Future<void> logout({required String baseUrl, required String sessionToken}) {
+    return ApiClient(baseUrl: baseUrl, accessToken: sessionToken).logout();
   }
 
   ApiClient buildAuthenticatedClient(StoredAuthSession session) {

--- a/mobile/lib/features/auth/session_controller.dart
+++ b/mobile/lib/features/auth/session_controller.dart
@@ -14,11 +14,10 @@ class SessionState {
   const SessionState.loading() : this._(status: SessionStatus.loading);
 
   const SessionState.authenticated(StoredAuthSession session)
-      : this._(status: SessionStatus.authenticated, session: session);
+    : this._(status: SessionStatus.authenticated, session: session);
 
   const SessionState.unauthenticated({String? errorMessage})
-      : this._(
-            status: SessionStatus.unauthenticated, errorMessage: errorMessage);
+    : this._(status: SessionStatus.unauthenticated, errorMessage: errorMessage);
 
   final SessionStatus status;
   final StoredAuthSession? session;
@@ -30,10 +29,10 @@ class SessionController extends ValueNotifier<SessionState> {
     required AuthSessionStore sessionStore,
     required AuthProfileStore profileStore,
     required AuthRepository authRepository,
-  })  : _sessionStore = sessionStore,
-        _profileStore = profileStore,
-        _authRepository = authRepository,
-        super(const SessionState.loading());
+  }) : _sessionStore = sessionStore,
+       _profileStore = profileStore,
+       _authRepository = authRepository,
+       super(const SessionState.loading());
 
   final AuthSessionStore _sessionStore;
   final AuthProfileStore _profileStore;
@@ -55,20 +54,19 @@ class SessionController extends ValueNotifier<SessionState> {
 
     try {
       final user = await _authRepository.fetchCurrentUser(
-          baseUrl: storedSession.baseUrl,
-          sessionToken: storedSession.session.sessionToken);
+        baseUrl: storedSession.baseUrl,
+        sessionToken: storedSession.session.sessionToken,
+      );
       final session = StoredAuthSession(
-          baseUrl: storedSession.baseUrl,
-          session: AuthSession(
-            sessionToken: storedSession.session.sessionToken,
-            user: user,
-          ));
+        baseUrl: storedSession.baseUrl,
+        session: AuthSession(
+          sessionToken: storedSession.session.sessionToken,
+          user: user,
+        ),
+      );
 
       await _sessionStore.write(session);
-      _profile = SavedAuthProfile(
-        baseUrl: session.baseUrl,
-        email: user.email,
-      );
+      _profile = SavedAuthProfile(baseUrl: session.baseUrl, email: user.email);
       await _profileStore.write(_profile!);
       value = SessionState.authenticated(session);
     } on ApiException catch (error) {
@@ -90,7 +88,8 @@ class SessionController extends ValueNotifier<SessionState> {
       );
       await _profileStore.write(_profile!);
       value = const SessionState.unauthenticated(
-          errorMessage: 'Nie udało się przywrócić zapisanej sesji.');
+        errorMessage: 'Nie udało się przywrócić zapisanej sesji.',
+      );
     }
   }
 
@@ -118,7 +117,8 @@ class SessionController extends ValueNotifier<SessionState> {
       value = SessionState.unauthenticated(errorMessage: error.message);
     } catch (_) {
       value = const SessionState.unauthenticated(
-          errorMessage: 'Nie udało się teraz wysłać kodu logowania.');
+        errorMessage: 'Nie udało się teraz wysłać kodu logowania.',
+      );
     }
   }
 
@@ -144,7 +144,9 @@ class SessionController extends ValueNotifier<SessionState> {
         displayName: displayName,
       );
       final session = StoredAuthSession(
-          baseUrl: normalizeBaseUrl(baseUrl), session: response);
+        baseUrl: normalizeBaseUrl(baseUrl),
+        session: response,
+      );
 
       await _sessionStore.write(session);
       value = SessionState.authenticated(session);
@@ -152,7 +154,8 @@ class SessionController extends ValueNotifier<SessionState> {
       value = SessionState.unauthenticated(errorMessage: error.message);
     } catch (_) {
       value = const SessionState.unauthenticated(
-          errorMessage: 'Nie udało się teraz zweryfikować kodu.');
+        errorMessage: 'Nie udało się teraz zweryfikować kodu.',
+      );
     }
   }
 
@@ -172,6 +175,33 @@ class SessionController extends ValueNotifier<SessionState> {
 
     await _sessionStore.clear();
     value = const SessionState.unauthenticated();
+  }
+
+  Future<void> updatePhoneNumber(String? phoneNumber) async {
+    final currentSession = value.session;
+
+    if (currentSession == null) {
+      throw const ApiException(
+        'Sesja wygasła. Zaloguj się ponownie.',
+        statusCode: 401,
+      );
+    }
+
+    final updatedUser = await _authRepository.updatePhoneNumber(
+      baseUrl: currentSession.baseUrl,
+      sessionToken: currentSession.session.sessionToken,
+      phoneNumber: phoneNumber,
+    );
+    final updatedSession = StoredAuthSession(
+      baseUrl: currentSession.baseUrl,
+      session: AuthSession(
+        sessionToken: currentSession.session.sessionToken,
+        user: updatedUser,
+      ),
+    );
+
+    await _sessionStore.write(updatedSession);
+    value = SessionState.authenticated(updatedSession);
   }
 
   Future<void> resetLocalData() async {

--- a/mobile/lib/features/auth/settings_page.dart
+++ b/mobile/lib/features/auth/settings_page.dart
@@ -1,16 +1,54 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
+import 'auth_models.dart';
 import 'auth_profile_store.dart';
 
-class SettingsPage extends StatelessWidget {
+class SettingsPage extends StatefulWidget {
   const SettingsPage({
+    required this.currentUser,
+    required this.onUpdatePhoneNumber,
     this.savedProfile,
     this.onResetLocalData,
     super.key,
   });
 
+  final AuthUser currentUser;
+  final Future<AuthUser> Function(String? phoneNumber) onUpdatePhoneNumber;
   final SavedAuthProfile? savedProfile;
   final Future<void> Function()? onResetLocalData;
+
+  @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  late final TextEditingController _phoneController;
+  late final FocusNode _phoneFocusNode;
+
+  bool _isSaving = false;
+  String? _errorMessage;
+  String? _savedPhoneNumber;
+
+  @override
+  void initState() {
+    super.initState();
+    _savedPhoneNumber = widget.currentUser.phoneNumber;
+    _phoneController = TextEditingController(text: _savedPhoneNumber ?? '');
+    _phoneFocusNode = FocusNode();
+  }
+
+  @override
+  void dispose() {
+    _phoneController.dispose();
+    _phoneFocusNode.dispose();
+    super.dispose();
+  }
+
+  bool get _hasSavedPhoneNumber => (_savedPhoneNumber ?? '').trim().isNotEmpty;
+
+  String get _phoneButtonLabel =>
+      _hasSavedPhoneNumber ? 'Zapisz zmiany' : 'Zapisz numer';
 
   Future<void> _confirmAndReset(BuildContext context) async {
     final shouldReset = await showDialog<bool>(
@@ -35,14 +73,120 @@ class SettingsPage extends StatelessWidget {
       },
     );
 
-    if (shouldReset != true || onResetLocalData == null) {
+    if (shouldReset != true || widget.onResetLocalData == null) {
       return;
     }
 
-    await onResetLocalData!();
+    await widget.onResetLocalData!();
 
     if (context.mounted && Navigator.of(context).canPop()) {
       Navigator.of(context).pop();
+    }
+  }
+
+  String? _validatePhoneNumber(String rawValue) {
+    final trimmed = rawValue.trim();
+
+    if (trimmed.isEmpty) {
+      return 'Wpisz numer telefonu albo użyj przycisku Usuń numer.';
+    }
+
+    final normalized = trimmed.replaceAll(RegExp(r'\s+'), '');
+    if (!RegExp(r'^\+[1-9]\d{7,14}$').hasMatch(normalized)) {
+      return 'Podaj numer w formacie międzynarodowym, np. +48123123123.';
+    }
+
+    return null;
+  }
+
+  Future<void> _savePhoneNumber() async {
+    final validationMessage = _validatePhoneNumber(_phoneController.text);
+    if (validationMessage != null) {
+      setState(() {
+        _errorMessage = validationMessage;
+      });
+      _phoneFocusNode.requestFocus();
+      return;
+    }
+
+    setState(() {
+      _isSaving = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final updatedUser = await widget.onUpdatePhoneNumber(
+        _phoneController.text,
+      );
+
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _savedPhoneNumber = updatedUser.phoneNumber;
+        _phoneController.text = updatedUser.phoneNumber ?? '';
+      });
+
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Numer telefonu zapisany.')));
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _errorMessage = error is Exception
+            ? error.toString().replaceFirst('Exception: ', '')
+            : 'Nie udało się zapisać numeru telefonu.';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSaving = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _clearPhoneNumber() async {
+    setState(() {
+      _isSaving = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final updatedUser = await widget.onUpdatePhoneNumber(null);
+
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _savedPhoneNumber = updatedUser.phoneNumber;
+        _phoneController.clear();
+      });
+
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Numer telefonu usunięty.')));
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _errorMessage = error is Exception
+            ? error.toString().replaceFirst('Exception: ', '')
+            : 'Nie udało się usunąć numeru telefonu.';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSaving = false;
+        });
+      }
     }
   }
 
@@ -51,12 +195,79 @@ class SettingsPage extends StatelessWidget {
     final theme = Theme.of(context);
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Ustawienia'),
-      ),
+      appBar: AppBar(title: const Text('Ustawienia')),
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Konto i kontakt', style: theme.textTheme.titleMedium),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Dodaj swój numer telefonu, aby druga osoba mogła szybko otworzyć WhatsApp do kontaktu po udostępnieniu listy.',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 16),
+                  Text('Email konta', style: theme.textTheme.labelLarge),
+                  const SizedBox(height: 8),
+                  Text(widget.currentUser.email),
+                  const SizedBox(height: 16),
+                  Text(
+                    'Numer telefonu do WhatsApp',
+                    style: theme.textTheme.labelLarge,
+                  ),
+                  const SizedBox(height: 8),
+                  TextField(
+                    controller: _phoneController,
+                    focusNode: _phoneFocusNode,
+                    keyboardType: TextInputType.phone,
+                    enabled: !_isSaving,
+                    inputFormatters: [
+                      FilteringTextInputFormatter.allow(RegExp(r'[\d +]')),
+                    ],
+                    decoration: InputDecoration(
+                      hintText: '+48123123123',
+                      helperText: _hasSavedPhoneNumber
+                          ? 'Aktualnie zapisany numer: $_savedPhoneNumber'
+                          : 'Brak zapisanego numeru telefonu.',
+                    ),
+                  ),
+                  if (_errorMessage != null) ...[
+                    const SizedBox(height: 12),
+                    Text(
+                      _errorMessage!,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.error,
+                      ),
+                    ),
+                  ],
+                  const SizedBox(height: 16),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: FilledButton(
+                          onPressed: _isSaving ? null : _savePhoneNumber,
+                          child: Text(_phoneButtonLabel),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      OutlinedButton(
+                        onPressed: _isSaving || !_hasSavedPhoneNumber
+                            ? null
+                            : _clearPhoneNumber,
+                        child: const Text('Usuń numer'),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
           Card(
             child: Padding(
               padding: const EdgeInsets.all(16),
@@ -73,19 +284,19 @@ class SettingsPage extends StatelessWidget {
                     style: theme.textTheme.bodyMedium,
                   ),
                   const SizedBox(height: 16),
-                  if (savedProfile != null) ...[
+                  if (widget.savedProfile != null) ...[
                     Text(
                       'Zapisane dane logowania',
                       style: theme.textTheme.labelLarge,
                     ),
                     const SizedBox(height: 8),
-                    Text('Backend: ${savedProfile!.baseUrl}'),
+                    Text('Backend: ${widget.savedProfile!.baseUrl}'),
                     const SizedBox(height: 4),
-                    Text('Email: ${savedProfile!.email}'),
+                    Text('Email: ${widget.savedProfile!.email}'),
                     const SizedBox(height: 16),
                   ],
                   OutlinedButton(
-                    onPressed: onResetLocalData == null
+                    onPressed: widget.onResetLocalData == null
                         ? null
                         : () => _confirmAndReset(context),
                     child: const Text('Wyczyść zapisane dane'),

--- a/mobile/test/app_home_page_test.dart
+++ b/mobile/test/app_home_page_test.dart
@@ -17,6 +17,7 @@ void main() {
           id: 'user_1',
           email: 'test@test.com',
           displayName: 'Pio',
+          phoneNumber: null,
           createdAt: DateTime.parse('2026-03-29T10:00:00.000Z'),
           updatedAt: DateTime.parse('2026-03-29T10:00:00.000Z'),
         ),
@@ -29,6 +30,7 @@ void main() {
         home: AppHomePage(
           session: session,
           authRepository: authRepository,
+          onUpdatePhoneNumber: (_) async => session.session.user,
           onLogout: () async {},
           onResetLocalData: () async {},
           themeMode: ThemeMode.system,
@@ -60,6 +62,7 @@ void main() {
           id: 'user_1',
           email: 'test@test.com',
           displayName: 'Pio',
+          phoneNumber: null,
           createdAt: DateTime.parse('2026-03-29T10:00:00.000Z'),
           updatedAt: DateTime.parse('2026-03-29T10:00:00.000Z'),
         ),
@@ -72,6 +75,7 @@ void main() {
         home: AppHomePage(
           session: session,
           authRepository: authRepository,
+          onUpdatePhoneNumber: (_) async => session.session.user,
           onLogout: () async {},
           onResetLocalData: () async {},
           themeMode: ThemeMode.system,
@@ -104,7 +108,8 @@ class _FakeAuthRepository extends AuthRepository {
 }
 
 class _FakeApiClient extends ApiClient {
-  _FakeApiClient() : super(baseUrl: 'http://localhost:3000', accessToken: 'token');
+  _FakeApiClient()
+    : super(baseUrl: 'http://localhost:3000', accessToken: 'token');
 
   @override
   Future<List<ShoppingListSummary>> fetchLists({

--- a/mobile/test/auth_session_store_test.dart
+++ b/mobile/test/auth_session_store_test.dart
@@ -12,6 +12,7 @@ void main() {
         id: 'user_1',
         email: 'test@example.com',
         displayName: 'Test User',
+        phoneNumber: '+48123123123',
         createdAt: DateTime.parse('2026-03-30T10:00:00.000Z'),
         updatedAt: DateTime.parse('2026-03-30T10:00:00.000Z'),
       ),
@@ -24,13 +25,15 @@ void main() {
       session: buildSession(),
     );
 
-    final restored =
-        StoredAuthSession.fromStorageValue(session.toStorageValue());
+    final restored = StoredAuthSession.fromStorageValue(
+      session.toStorageValue(),
+    );
 
     expect(restored.baseUrl, 'http://localhost:3000');
     expect(restored.session.sessionToken, 'token_123');
     expect(restored.session.user.email, 'test@example.com');
     expect(restored.session.user.displayName, 'Test User');
+    expect(restored.session.user.phoneNumber, '+48123123123');
   });
 
   test('StoredAuthSession rejects malformed payloads', () {
@@ -66,7 +69,9 @@ void main() {
       email: 'test@example.com',
     );
 
-    final restored = SavedAuthProfile.fromStorageValue(profile.toStorageValue());
+    final restored = SavedAuthProfile.fromStorageValue(
+      profile.toStorageValue(),
+    );
 
     expect(restored.baseUrl, 'http://localhost:3000');
     expect(restored.email, 'test@example.com');

--- a/mobile/test/session_controller_test.dart
+++ b/mobile/test/session_controller_test.dart
@@ -26,9 +26,12 @@ void main() {
 
   test('bootstrap restores a saved session and refreshes the user', () async {
     final staleUser = _buildUser(displayName: 'Old Name');
-    await sessionStore.write(StoredAuthSession(
+    await sessionStore.write(
+      StoredAuthSession(
         baseUrl: 'http://localhost:3000',
-        session: AuthSession(sessionToken: 'saved-token', user: staleUser)));
+        session: AuthSession(sessionToken: 'saved-token', user: staleUser),
+      ),
+    );
     authRepository.currentUser = _buildUser(displayName: 'Fresh Name');
 
     await controller.bootstrap();
@@ -40,59 +43,76 @@ void main() {
     expect(profileStore.savedProfile?.email, 'test@example.com');
   });
 
-  test('bootstrap keeps remembered auth data when a saved session is invalid',
-      () async {
-    await sessionStore.write(StoredAuthSession(
-        baseUrl: 'http://localhost:3000',
-        session:
-            AuthSession(sessionToken: 'expired-token', user: _buildUser())));
-    authRepository.currentUserError =
-        const ApiException('User not found', statusCode: 401);
+  test(
+    'bootstrap keeps remembered auth data when a saved session is invalid',
+    () async {
+      await sessionStore.write(
+        StoredAuthSession(
+          baseUrl: 'http://localhost:3000',
+          session: AuthSession(
+            sessionToken: 'expired-token',
+            user: _buildUser(),
+          ),
+        ),
+      );
+      authRepository.currentUserError = const ApiException(
+        'User not found',
+        statusCode: 401,
+      );
 
-    await controller.bootstrap();
+      await controller.bootstrap();
 
-    expect(controller.value.status, SessionStatus.unauthenticated);
-    expect(controller.value.errorMessage, 'User not found');
-    expect(sessionStore.savedSession, isNull);
-    expect(profileStore.savedProfile?.baseUrl, 'http://localhost:3000');
-    expect(profileStore.savedProfile?.email, 'test@example.com');
-  });
+      expect(controller.value.status, SessionStatus.unauthenticated);
+      expect(controller.value.errorMessage, 'User not found');
+      expect(sessionStore.savedSession, isNull);
+      expect(profileStore.savedProfile?.baseUrl, 'http://localhost:3000');
+      expect(profileStore.savedProfile?.email, 'test@example.com');
+    },
+  );
 
-  test('bootstrap keeps remembered auth data when the backend is unavailable',
-      () async {
-    await sessionStore.write(StoredAuthSession(
-        baseUrl: 'http://localhost:3000',
-        session:
-            AuthSession(sessionToken: 'saved-token', user: _buildUser())));
-    authRepository.currentUserError = const ApiException('Request timed out');
+  test(
+    'bootstrap keeps remembered auth data when the backend is unavailable',
+    () async {
+      await sessionStore.write(
+        StoredAuthSession(
+          baseUrl: 'http://localhost:3000',
+          session: AuthSession(sessionToken: 'saved-token', user: _buildUser()),
+        ),
+      );
+      authRepository.currentUserError = const ApiException('Request timed out');
 
-    await controller.bootstrap();
+      await controller.bootstrap();
 
-    expect(controller.value.status, SessionStatus.unauthenticated);
-    expect(controller.value.errorMessage, 'Request timed out');
-    expect(sessionStore.savedSession, isNotNull);
-    expect(profileStore.savedProfile?.baseUrl, 'http://localhost:3000');
-    expect(profileStore.savedProfile?.email, 'test@example.com');
-  });
+      expect(controller.value.status, SessionStatus.unauthenticated);
+      expect(controller.value.errorMessage, 'Request timed out');
+      expect(sessionStore.savedSession, isNotNull);
+      expect(profileStore.savedProfile?.baseUrl, 'http://localhost:3000');
+      expect(profileStore.savedProfile?.email, 'test@example.com');
+    },
+  );
 
-  test('requestCode leaves the controller unauthenticated on success',
-      () async {
-    await controller.requestCode(
-      baseUrl: 'http://localhost:3000/',
-      email: 'test@example.com',
-      displayName: 'Tester',
-    );
+  test(
+    'requestCode leaves the controller unauthenticated on success',
+    () async {
+      await controller.requestCode(
+        baseUrl: 'http://localhost:3000/',
+        email: 'test@example.com',
+        displayName: 'Tester',
+      );
 
-    expect(controller.value.status, SessionStatus.unauthenticated);
-    expect(sessionStore.savedSession, isNull);
-    expect(profileStore.savedProfile?.baseUrl, 'http://localhost:3000');
-    expect(profileStore.savedProfile?.email, 'test@example.com');
-    expect(authRepository.requestCodeCalls, 1);
-  });
+      expect(controller.value.status, SessionStatus.unauthenticated);
+      expect(sessionStore.savedSession, isNull);
+      expect(profileStore.savedProfile?.baseUrl, 'http://localhost:3000');
+      expect(profileStore.savedProfile?.email, 'test@example.com');
+      expect(authRepository.requestCodeCalls, 1);
+    },
+  );
 
   test('verifyCode persists the authenticated session', () async {
     authRepository.verifyCodeResponse = AuthSession(
-        sessionToken: 'new-token', user: _buildUser(displayName: 'Tester'));
+      sessionToken: 'new-token',
+      user: _buildUser(displayName: 'Tester'),
+    );
 
     await controller.verifyCode(
       baseUrl: 'http://localhost:3000/',
@@ -109,32 +129,33 @@ void main() {
     expect(profileStore.savedProfile?.email, 'test@example.com');
   });
 
-  test('verifyCode surfaces backend errors without persisting a session',
-      () async {
-    authRepository.verifyCodeError =
-        const ApiException('Invalid code', statusCode: 401);
+  test(
+    'verifyCode surfaces backend errors without persisting a session',
+    () async {
+      authRepository.verifyCodeError = const ApiException(
+        'Invalid code',
+        statusCode: 401,
+      );
 
-    await controller.verifyCode(
-      baseUrl: 'http://localhost:3000',
-      email: 'taken@example.com',
-      code: '000000',
-      displayName: 'Taken User',
-    );
+      await controller.verifyCode(
+        baseUrl: 'http://localhost:3000',
+        email: 'taken@example.com',
+        code: '000000',
+        displayName: 'Taken User',
+      );
 
-    expect(controller.value.status, SessionStatus.unauthenticated);
-    expect(controller.value.errorMessage, 'Invalid code');
-    expect(sessionStore.savedSession, isNull);
-    expect(profileStore.savedProfile?.baseUrl, 'http://localhost:3000');
-    expect(profileStore.savedProfile?.email, 'taken@example.com');
-  });
+      expect(controller.value.status, SessionStatus.unauthenticated);
+      expect(controller.value.errorMessage, 'Invalid code');
+      expect(sessionStore.savedSession, isNull);
+      expect(profileStore.savedProfile?.baseUrl, 'http://localhost:3000');
+      expect(profileStore.savedProfile?.email, 'taken@example.com');
+    },
+  );
 
   test('logout clears the local session and revokes remotely', () async {
     final session = StoredAuthSession(
       baseUrl: 'http://localhost:3000',
-      session: AuthSession(
-        sessionToken: 'session-token',
-        user: _buildUser(),
-      ),
+      session: AuthSession(sessionToken: 'session-token', user: _buildUser()),
     );
     await sessionStore.write(session);
     controller.value = SessionState.authenticated(session);
@@ -148,10 +169,12 @@ void main() {
   });
 
   test('resetLocalData clears both the saved session and profile', () async {
-    await sessionStore.write(StoredAuthSession(
-      baseUrl: 'http://localhost:3000',
-      session: AuthSession(sessionToken: 'saved-token', user: _buildUser()),
-    ));
+    await sessionStore.write(
+      StoredAuthSession(
+        baseUrl: 'http://localhost:3000',
+        session: AuthSession(sessionToken: 'saved-token', user: _buildUser()),
+      ),
+    );
     await profileStore.write(
       const SavedAuthProfile(
         baseUrl: 'http://localhost:3000',
@@ -166,34 +189,117 @@ void main() {
     expect(profileStore.savedProfile, isNull);
   });
 
-  test('requestCode returns a Polish fallback when an unexpected error occurs',
-      () async {
-    authRepository.throwUnexpectedOnRequestCode = true;
+  test(
+    'requestCode returns a Polish fallback when an unexpected error occurs',
+    () async {
+      authRepository.throwUnexpectedOnRequestCode = true;
 
-    await controller.requestCode(
-      baseUrl: 'http://localhost:3000/',
-      email: 'test@example.com',
-    );
+      await controller.requestCode(
+        baseUrl: 'http://localhost:3000/',
+        email: 'test@example.com',
+      );
 
-    expect(
-      controller.value.errorMessage,
-      'Nie udało się teraz wysłać kodu logowania.',
+      expect(
+        controller.value.errorMessage,
+        'Nie udało się teraz wysłać kodu logowania.',
+      );
+    },
+  );
+
+  test(
+    'verifyCode returns a Polish fallback when an unexpected error occurs',
+    () async {
+      authRepository.throwUnexpectedOnVerifyCode = true;
+
+      await controller.verifyCode(
+        baseUrl: 'http://localhost:3000/',
+        email: 'test@example.com',
+        code: '123456',
+      );
+
+      expect(
+        controller.value.errorMessage,
+        'Nie udało się teraz zweryfikować kodu.',
+      );
+    },
+  );
+
+  test('updatePhoneNumber refreshes the authenticated session user', () async {
+    final session = StoredAuthSession(
+      baseUrl: 'http://localhost:3000',
+      session: AuthSession(sessionToken: 'saved-token', user: _buildUser()),
     );
+    await sessionStore.write(session);
+    controller.value = SessionState.authenticated(session);
+    authRepository.updatedUser = _buildUser(phoneNumber: '+48123123123');
+
+    await controller.updatePhoneNumber('+48 123 123 123');
+
+    expect(controller.value.status, SessionStatus.authenticated);
+    expect(controller.value.session?.session.user.phoneNumber, '+48123123123');
+    expect(sessionStore.savedSession?.session.user.phoneNumber, '+48123123123');
+    expect(authRepository.lastUpdatedPhoneNumber, '+48 123 123 123');
   });
 
-  test('verifyCode returns a Polish fallback when an unexpected error occurs',
-      () async {
-    authRepository.throwUnexpectedOnVerifyCode = true;
-
-    await controller.verifyCode(
-      baseUrl: 'http://localhost:3000/',
-      email: 'test@example.com',
-      code: '123456',
+  test('updatePhoneNumber can clear the saved phone number', () async {
+    final session = StoredAuthSession(
+      baseUrl: 'http://localhost:3000',
+      session: AuthSession(
+        sessionToken: 'saved-token',
+        user: _buildUser(phoneNumber: '+48123123123'),
+      ),
     );
+    await sessionStore.write(session);
+    controller.value = SessionState.authenticated(session);
+    authRepository.updatedUser = _buildUser(phoneNumber: null);
 
-    expect(
-      controller.value.errorMessage,
-      'Nie udało się teraz zweryfikować kodu.',
+    await controller.updatePhoneNumber(null);
+
+    expect(controller.value.session?.session.user.phoneNumber, isNull);
+    expect(sessionStore.savedSession?.session.user.phoneNumber, isNull);
+    expect(authRepository.lastUpdatedPhoneNumber, isNull);
+  });
+
+  test(
+    'updatePhoneNumber surfaces backend errors and keeps the session',
+    () async {
+      final session = StoredAuthSession(
+        baseUrl: 'http://localhost:3000',
+        session: AuthSession(sessionToken: 'saved-token', user: _buildUser()),
+      );
+      await sessionStore.write(session);
+      controller.value = SessionState.authenticated(session);
+      authRepository.updatePhoneNumberError = const ApiException(
+        'Nieprawidłowy numer telefonu',
+        statusCode: 400,
+      );
+
+      await expectLater(
+        controller.updatePhoneNumber('123'),
+        throwsA(
+          isA<ApiException>().having(
+            (error) => error.message,
+            'message',
+            'Nieprawidłowy numer telefonu',
+          ),
+        ),
+      );
+
+      expect(controller.value.session?.session.user.phoneNumber, isNull);
+      expect(sessionStore.savedSession?.session.user.phoneNumber, isNull);
+    },
+  );
+
+  test('updatePhoneNumber rejects missing authenticated session', () async {
+    await expectLater(
+      controller.updatePhoneNumber('+48123123123'),
+      throwsA(
+        isA<ApiException>().having(
+          (error) => error.statusCode,
+          'statusCode',
+          401,
+        ),
+      ),
     );
   });
 }
@@ -237,14 +343,17 @@ class _InMemoryProfileStore extends InMemoryAuthProfileStore {
 class _FakeAuthRepository extends AuthRepository {
   AuthSession? verifyCodeResponse;
   AuthUser? currentUser;
+  AuthUser? updatedUser;
   ApiException? requestCodeError;
   ApiException? verifyCodeError;
   ApiException? currentUserError;
+  ApiException? updatePhoneNumberError;
   bool throwUnexpectedOnRequestCode = false;
   bool throwUnexpectedOnVerifyCode = false;
   int requestCodeCalls = 0;
   int verifyCodeCalls = 0;
   int logoutCalls = 0;
+  String? lastUpdatedPhoneNumber;
 
   @override
   Future<void> requestCode({
@@ -285,13 +394,30 @@ class _FakeAuthRepository extends AuthRepository {
   }
 
   @override
-  Future<AuthUser> fetchCurrentUser(
-      {required String baseUrl, required String sessionToken}) async {
+  Future<AuthUser> fetchCurrentUser({
+    required String baseUrl,
+    required String sessionToken,
+  }) async {
     if (currentUserError != null) {
       throw currentUserError!;
     }
 
     return currentUser ?? _buildUser();
+  }
+
+  @override
+  Future<AuthUser> updatePhoneNumber({
+    required String baseUrl,
+    required String sessionToken,
+    required String? phoneNumber,
+  }) async {
+    lastUpdatedPhoneNumber = phoneNumber;
+
+    if (updatePhoneNumberError != null) {
+      throw updatePhoneNumberError!;
+    }
+
+    return updatedUser ?? _buildUser(phoneNumber: phoneNumber);
   }
 
   @override
@@ -303,11 +429,13 @@ class _FakeAuthRepository extends AuthRepository {
   }
 }
 
-AuthUser _buildUser({String displayName = 'Test User'}) {
+AuthUser _buildUser({String displayName = 'Test User', String? phoneNumber}) {
   return AuthUser(
-      id: 'user_1',
-      email: 'test@example.com',
-      displayName: displayName,
-      createdAt: DateTime.parse('2026-03-29T10:00:00.000Z'),
-      updatedAt: DateTime.parse('2026-03-29T10:00:00.000Z'));
+    id: 'user_1',
+    email: 'test@example.com',
+    displayName: displayName,
+    phoneNumber: phoneNumber,
+    createdAt: DateTime.parse('2026-03-29T10:00:00.000Z'),
+    updatedAt: DateTime.parse('2026-03-29T10:00:00.000Z'),
+  );
 }

--- a/mobile/test/settings_page_test.dart
+++ b/mobile/test/settings_page_test.dart
@@ -1,21 +1,186 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zakupy_mobile/features/auth/auth_models.dart';
 import 'package:zakupy_mobile/features/auth/auth_profile_store.dart';
 import 'package:zakupy_mobile/features/auth/settings_page.dart';
 
 void main() {
-  testWidgets('SettingsPage shows saved auth data and resets it', (
+  testWidgets('SettingsPage shows saved auth data and current phone number', (
     tester,
   ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SettingsPage(
+          currentUser: _buildUser(phoneNumber: '+48123123123'),
+          savedProfile: const SavedAuthProfile(
+            baseUrl: 'http://localhost:3000',
+            email: 'test@example.com',
+          ),
+          onUpdatePhoneNumber: (phoneNumber) async =>
+              _buildUser(phoneNumber: phoneNumber),
+          onResetLocalData: () async {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Backend: http://localhost:3000'), findsOneWidget);
+    expect(find.text('Email: test@example.com'), findsOneWidget);
+    expect(find.text('test@example.com'), findsOneWidget);
+    expect(find.text('Aktualnie zapisany numer: +48123123123'), findsOneWidget);
+  });
+
+  testWidgets('SettingsPage saves a valid phone number', (tester) async {
+    String? savedPhoneNumber;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SettingsPage(
+          currentUser: _buildUser(),
+          onUpdatePhoneNumber: (phoneNumber) async {
+            savedPhoneNumber = phoneNumber;
+            return _buildUser(phoneNumber: '+48123123123');
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), ' +48 123 123 123 ');
+    await tester.tap(find.text('Zapisz numer'));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(savedPhoneNumber, ' +48 123 123 123 ');
+    expect(find.text('Numer telefonu zapisany.'), findsOneWidget);
+    expect(find.text('Aktualnie zapisany numer: +48123123123'), findsOneWidget);
+  });
+
+  testWidgets('SettingsPage validates phone number before saving', (
+    tester,
+  ) async {
+    var saveCalls = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SettingsPage(
+          currentUser: _buildUser(),
+          onUpdatePhoneNumber: (phoneNumber) async {
+            saveCalls += 1;
+            return _buildUser(phoneNumber: phoneNumber);
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), '123');
+    await tester.tap(find.text('Zapisz numer'));
+    await tester.pumpAndSettle();
+
+    expect(saveCalls, 0);
+    expect(
+      find.text('Podaj numer w formacie międzynarodowym, np. +48123123123.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('SettingsPage disables actions while saving', (tester) async {
+    final completer = Completer<AuthUser>();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SettingsPage(
+          currentUser: _buildUser(),
+          onUpdatePhoneNumber: (_) => completer.future,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), '+48123123123');
+    await tester.tap(find.text('Zapisz numer'));
+    await tester.pump();
+
+    final filledButton = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, 'Zapisz numer'),
+    );
+    final textField = tester.widget<TextField>(find.byType(TextField));
+
+    expect(filledButton.onPressed, isNull);
+    expect(textField.enabled, isFalse);
+
+    completer.complete(_buildUser(phoneNumber: '+48123123123'));
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('SettingsPage shows backend errors when saving fails', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SettingsPage(
+          currentUser: _buildUser(),
+          onUpdatePhoneNumber: (_) async {
+            throw Exception('Nie udało się zapisać zmian.');
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), '+48123123123');
+    await tester.tap(find.text('Zapisz numer'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Nie udało się zapisać zmian.'), findsOneWidget);
+  });
+
+  testWidgets('SettingsPage clears the saved phone number', (tester) async {
+    String? clearedValue = 'unchanged';
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SettingsPage(
+          currentUser: _buildUser(phoneNumber: '+48123123123'),
+          onUpdatePhoneNumber: (phoneNumber) async {
+            clearedValue = phoneNumber;
+            return _buildUser(phoneNumber: null);
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Usuń numer'));
+    await tester.pumpAndSettle();
+
+    expect(clearedValue, isNull);
+    expect(find.text('Numer telefonu usunięty.'), findsOneWidget);
+    expect(find.text('Brak zapisanego numeru telefonu.'), findsOneWidget);
+  });
+
+  testWidgets('SettingsPage resets saved auth data after confirmation', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(800, 1400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
     var resetCalls = 0;
 
     await tester.pumpWidget(
       MaterialApp(
         home: SettingsPage(
+          currentUser: _buildUser(),
           savedProfile: const SavedAuthProfile(
             baseUrl: 'http://localhost:3000',
             email: 'test@example.com',
           ),
+          onUpdatePhoneNumber: (phoneNumber) async =>
+              _buildUser(phoneNumber: phoneNumber),
           onResetLocalData: () async {
             resetCalls += 1;
           },
@@ -24,9 +189,6 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Backend: http://localhost:3000'), findsOneWidget);
-    expect(find.text('Email: test@example.com'), findsOneWidget);
-
     await tester.tap(find.text('Wyczyść zapisane dane'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Wyczyść'));
@@ -34,4 +196,15 @@ void main() {
 
     expect(resetCalls, 1);
   });
+}
+
+AuthUser _buildUser({String? phoneNumber}) {
+  return AuthUser(
+    id: 'user_1',
+    email: 'test@example.com',
+    displayName: 'Test User',
+    phoneNumber: phoneNumber,
+    createdAt: DateTime.parse('2026-03-29T10:00:00.000Z'),
+    updatedAt: DateTime.parse('2026-03-29T10:00:00.000Z'),
+  );
 }


### PR DESCRIPTION
## Summary

- adds phone-number management to the authenticated Settings flow
- wires the screen to the backend `PATCH /auth/me` profile contract
- keeps the stored authenticated user in sync after successful updates and covers the flow with tests

## Progress

- [x] implementation
- [x] widget tests
- [x] controller/store tests

## GitHub workflow

- Closes #62
- Parent #59
- Project status: `In Progress`

## Validation

- `flutter test test/settings_page_test.dart test/session_controller_test.dart test/app_home_page_test.dart test/auth_session_store_test.dart`

## Notes

- this PR is limited to the Settings/auth slice
- the list-detail WhatsApp button remains in the paired issue #63
