### PR TITLE
Add removal for saved item suggestions

### DIFF
--- a/backend/src/modules/items/routes.test.ts
+++ b/backend/src/modules/items/routes.test.ts
@@ -207,8 +207,13 @@ async function buildApp(
       findFirst: async ({
         where
       }: {
-        where: { userId: string; normalizedName: string; normalizedComment: string };
+        where: { userId: string; id?: string; normalizedName?: string; normalizedComment?: string };
       }) => {
+        if (where.id) {
+          const suggestion = suggestionsById.get(where.id) ?? null;
+          return suggestion?.userId === where.userId ? suggestion : null;
+        }
+
         return (
           [...suggestionsById.values()].find(
             (suggestion) =>
@@ -280,6 +285,16 @@ async function buildApp(
 
         suggestionsById.set(where.id, updatedSuggestion);
         return updatedSuggestion;
+      },
+      delete: async ({ where }: { where: { id: string } }) => {
+        const suggestion = suggestionsById.get(where.id);
+
+        if (!suggestion) {
+          throw new Error('Suggestion not found');
+        }
+
+        suggestionsById.delete(where.id);
+        return suggestion;
       }
     },
     shoppingList: {
@@ -458,6 +473,50 @@ test('GET /items/suggestions returns ranked suggestions for the user', async () 
     assert.equal(response.statusCode, 200);
     assert.deepEqual(response.json().items.map((item: { name: string }) => item.name), ['Milk', 'Batteries']);
     assert.equal(response.json().items[0].iconKey, 'eggs');
+  } finally {
+    await app.close();
+  }
+});
+
+test('DELETE /items/suggestions/:suggestionId removes the user suggestion', async () => {
+  const user = buildUser();
+  const suggestions = new Map<string, TestSuggestion | undefined>([
+    ['suggestion_1', buildSuggestion({ id: 'suggestion_1', userId: user.id })]
+  ]);
+  const { rawToken, session } = buildSessionToken(user.id);
+  const app = await buildApp(new Map([[user.id, user]]), new Map(), new Map(), suggestions, [session]);
+
+  try {
+    const response = await app.inject({
+      method: 'DELETE',
+      url: '/items/suggestions/suggestion_1',
+      headers: { authorization: `Bearer ${rawToken}` }
+    });
+
+    assert.equal(response.statusCode, 204);
+    assert.equal(suggestions.size, 0);
+  } finally {
+    await app.close();
+  }
+});
+
+test('DELETE /items/suggestions/:suggestionId returns 404 for another user suggestion', async () => {
+  const user = buildUser({ id: 'user_1' });
+  const suggestions = new Map<string, TestSuggestion | undefined>([
+    ['suggestion_1', buildSuggestion({ id: 'suggestion_1', userId: 'user_2' })]
+  ]);
+  const { rawToken, session } = buildSessionToken(user.id);
+  const app = await buildApp(new Map([[user.id, user]]), new Map(), new Map(), suggestions, [session]);
+
+  try {
+    const response = await app.inject({
+      method: 'DELETE',
+      url: '/items/suggestions/suggestion_1',
+      headers: { authorization: `Bearer ${rawToken}` }
+    });
+
+    assert.equal(response.statusCode, 404);
+    assert.equal(suggestions.size, 1);
   } finally {
     await app.close();
   }

--- a/backend/src/modules/items/routes.ts
+++ b/backend/src/modules/items/routes.ts
@@ -154,8 +154,9 @@ type ItemRoutesDeps = {
       findFirst(args: {
         where: {
           userId: string;
-          normalizedName: string;
-          normalizedComment: string;
+          id?: string;
+          normalizedName?: string;
+          normalizedComment?: string;
         };
       }): Promise<ItemSuggestionRecord | null>;
       create(args: {
@@ -179,6 +180,9 @@ type ItemRoutesDeps = {
           usageCount?: { increment: number };
           lastUsedAt?: Date;
         };
+      }): Promise<ItemSuggestionRecord>;
+      delete(args: {
+        where: { id: string };
       }): Promise<ItemSuggestionRecord>;
     };
     shoppingList: ListRepository;
@@ -408,6 +412,34 @@ export function createItemRoutes(deps: ItemRoutesDeps = defaultDeps): FastifyPlu
       return {
         items: suggestions.map(toSuggestionResponse)
       };
+    });
+
+    app.delete('/items/suggestions/:suggestionId', async (request, reply) => {
+      const user = await authenticateRequest(deps.prisma, request, reply);
+
+      if (!user) {
+        return;
+      }
+
+      const { suggestionId } = request.params as { suggestionId: string };
+      const suggestion = await deps.prisma.itemSuggestion.findFirst({
+        where: {
+          id: suggestionId,
+          userId: user.id
+        }
+      });
+
+      if (!suggestion) {
+        return reply.notFound('Suggestion not found');
+      }
+
+      await deps.prisma.itemSuggestion.delete({
+        where: {
+          id: suggestion.id
+        }
+      });
+
+      return reply.status(204).send();
     });
 
     app.get('/lists/:listId/items', async (request, reply) => {

--- a/mobile/lib/core/network/api_client.dart
+++ b/mobile/lib/core/network/api_client.dart
@@ -276,6 +276,15 @@ class ApiClient {
     });
   }
 
+  Future<void> deleteItemSuggestion(String suggestionId) {
+    return _guard(() async {
+      await _dio.delete<void>(
+        '/items/suggestions/$suggestionId',
+        options: _authOptions(),
+      );
+    });
+  }
+
   Future<ShoppingListItem> createItem(String listId, ItemDraft draft) {
     return _guard(() async {
       final response = await _dio.post<Map<String, dynamic>>(

--- a/mobile/lib/features/lists/list_detail_page.dart
+++ b/mobile/lib/features/lists/list_detail_page.dart
@@ -689,6 +689,71 @@ class _ListDetailPageState extends State<ListDetailPage> {
     }
   }
 
+  Future<void> _confirmDeleteSuggestion(ItemSuggestion suggestion) async {
+    final shouldDelete = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        final suggestionLabel =
+            suggestion.comment == null || suggestion.comment!.isEmpty
+                ? suggestion.name
+                : '${suggestion.name} • ${suggestion.comment}';
+        return AlertDialog(
+          title: const Text('Usunąć sugestię?'),
+          content: Text(
+            'Usunąć sugestię „$suggestionLabel” z Twojej listy podpowiedzi?',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: const Text('Anuluj'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: const Text('Usuń'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (shouldDelete != true) {
+      return;
+    }
+
+    try {
+      await widget.apiClient.deleteItemSuggestion(suggestion.id);
+
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _suggestions.removeWhere((entry) => entry.id == suggestion.id);
+      });
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Usunięto sugestię „${suggestion.name}”.'),
+        ),
+      );
+    } on ApiException catch (error) {
+      if (error.isUnauthorized && widget.onUnauthorized != null) {
+        await widget.onUnauthorized!();
+        return;
+      }
+
+      if (!mounted) {
+        return;
+      }
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Nie udało się usunąć sugestii: ${error.message}'),
+        ),
+      );
+    }
+  }
+
   Future<void> _shareList() async {
     if (_isSharing) {
       return;
@@ -1282,7 +1347,7 @@ class _ListDetailPageState extends State<ListDetailPage> {
         ),
         const SizedBox(height: 8),
         Text(
-          'Najczęściej dodawane produkty',
+          'Najczęściej dodawane produkty. Przytrzymaj sugestię, aby ją usunąć.',
           style: Theme.of(context).textTheme.bodySmall?.copyWith(
                 color: Theme.of(context).colorScheme.onSurfaceVariant,
               ),
@@ -1294,21 +1359,24 @@ class _ListDetailPageState extends State<ListDetailPage> {
           children: _suggestions.map(
             (suggestion) {
               final iconOption = itemIconOptionForKey(suggestion.iconKey);
-              return ActionChip(
-                backgroundColor: Theme.of(context)
-                    .colorScheme
-                    .surfaceContainerHighest
-                    .withValues(alpha: 0.6),
-                avatar: Tooltip(
-                  message: iconOption.label,
-                  child: buildItemIconBadge(iconOption, size: 24),
+              return GestureDetector(
+                onLongPress: () => _confirmDeleteSuggestion(suggestion),
+                child: ActionChip(
+                  backgroundColor: Theme.of(context)
+                      .colorScheme
+                      .surfaceContainerHighest
+                      .withValues(alpha: 0.6),
+                  avatar: Tooltip(
+                    message: iconOption.label,
+                    child: buildItemIconBadge(iconOption, size: 24),
+                  ),
+                  label: Text(
+                    suggestion.comment == null || suggestion.comment!.isEmpty
+                        ? suggestion.name
+                        : '${suggestion.name} • ${suggestion.comment}',
+                  ),
+                  onPressed: () => _addSuggestion(suggestion),
                 ),
-                label: Text(
-                  suggestion.comment == null || suggestion.comment!.isEmpty
-                      ? suggestion.name
-                      : '${suggestion.name} • ${suggestion.comment}',
-                ),
-                onPressed: () => _addSuggestion(suggestion),
               );
             },
           ).toList(growable: false),

--- a/mobile/test/list_detail_page_test.dart
+++ b/mobile/test/list_detail_page_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:zakupy_mobile/core/models/item_icon.dart';
 import 'package:zakupy_mobile/core/network/api_client.dart';
 import 'package:zakupy_mobile/features/lists/list_detail_page.dart';
 import 'package:zakupy_mobile/features/lists/share_list_dialog.dart';
@@ -458,6 +457,37 @@ void main() {
     expect(find.text('Milk'), findsOneWidget);
   });
 
+  testWidgets('removes a suggestion after long press confirmation', (
+    tester,
+  ) async {
+    final apiClient = _FakeApiClient(
+      items: <ShoppingListItem>[],
+      suggestions: <ItemSuggestion>[
+        ItemSuggestion(
+          id: 'suggestion_milk',
+          name: 'Milk',
+          comment: '2%',
+          iconKey: 'eggs',
+          usageCount: 12,
+          lastUsedAt: DateTime.utc(2026, 4, 10, 12),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(buildSubject(apiClient));
+    await tester.pumpAndSettle();
+
+    await tester.longPress(find.widgetWithText(ActionChip, 'Milk • 2%'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Usunąć sugestię?'), findsOneWidget);
+    await tester.tap(find.widgetWithText(FilledButton, 'Usuń'));
+    await tester.pumpAndSettle();
+
+    expect(apiClient.deletedSuggestionIds, ['suggestion_milk']);
+    expect(find.text('Milk • 2%'), findsNothing);
+  });
+
   testWidgets('increments item quantity on tap', (tester) async {
     final apiClient = _FakeApiClient(
       items: <ShoppingListItem>[_milkItem],
@@ -679,7 +709,6 @@ class _FakeApiClient extends ApiClient {
     this.createItemHandler,
     this.updateItemHandler,
     this.updateListHandler,
-    this.archiveListHandler,
     this.deleteItemHandler,
     this.fetchItemsHandler,
     this.shareListHandler,
@@ -704,7 +733,6 @@ class _FakeApiClient extends ApiClient {
     required String name,
     DateTime? plannedFor,
   })? updateListHandler;
-  final Future<ShoppingListSummary> Function(String listId)? archiveListHandler;
   final Future<void> Function(String listId, String itemId)? deleteItemHandler;
   final Future<ShareListResult> Function(String listId, String email)?
       shareListHandler;
@@ -716,6 +744,7 @@ class _FakeApiClient extends ApiClient {
   int archiveListCalls = 0;
   ItemDraft? lastCreatedDraft;
   ItemDraft? lastUpdatedDraft;
+  final List<String> deletedSuggestionIds = <String>[];
 
   @override
   Future<List<ShoppingListItem>> fetchItems(String listId) async {
@@ -818,10 +847,6 @@ class _FakeApiClient extends ApiClient {
   Future<ShoppingListSummary> archiveList(String listId) async {
     archiveListCalls += 1;
 
-    if (archiveListHandler != null) {
-      return archiveListHandler!(listId);
-    }
-
     return ShoppingListSummary(
       id: listId,
       name: 'Weekly groceries',
@@ -852,6 +877,12 @@ class _FakeApiClient extends ApiClient {
     }
 
     items.removeWhere((item) => item.id == itemId);
+  }
+
+  @override
+  Future<void> deleteItemSuggestion(String suggestionId) async {
+    deletedSuggestionIds.add(suggestionId);
+    suggestions.removeWhere((suggestion) => suggestion.id == suggestionId);
   }
 
   @override


### PR DESCRIPTION
## Summary
- add backend deletion for saved item suggestions scoped to the authenticated user
- add long-press delete with confirmation in the list suggestions section
- cover the new flow with backend route tests and a mobile widget test

## Validation
- `DATABASE_URL=postgresql://test:test@127.0.0.1:5432/test JWT_SECRET=test-secret node --import tsx --test src/modules/items/routes.test.ts`
- `npm run build`
- `flutter test test/list_detail_page_test.dart`
- `flutter analyze lib/features/lists/list_detail_page.dart lib/core/network/api_client.dart test/list_detail_page_test.dart`
