### PR TITLE
[codex] Share item suggestions across backend

### DIFF
--- a/backend/prisma/migrations/20260430120000_global_item_suggestions/migration.sql
+++ b/backend/prisma/migrations/20260430120000_global_item_suggestions/migration.sql
@@ -1,0 +1,71 @@
+CREATE TABLE "item_suggestions_new" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "normalized_name" TEXT NOT NULL,
+    "comment" TEXT,
+    "normalized_comment" TEXT NOT NULL DEFAULT '',
+    "icon_key" TEXT NOT NULL DEFAULT 'default',
+    "usage_count" INTEGER NOT NULL DEFAULT 1,
+    "last_used_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "item_suggestions_new_pkey" PRIMARY KEY ("id")
+);
+
+INSERT INTO "item_suggestions_new" (
+  "id",
+  "name",
+  "normalized_name",
+  "comment",
+  "normalized_comment",
+  "icon_key",
+  "usage_count",
+  "last_used_at",
+  "created_at",
+  "updated_at"
+)
+SELECT
+  md5(CONCAT("normalized_name", ':', "normalized_comment")),
+  chosen."name",
+  chosen."normalized_name",
+  chosen."comment",
+  chosen."normalized_comment",
+  chosen."icon_key",
+  totals."usage_count",
+  totals."last_used_at",
+  totals."created_at",
+  totals."updated_at"
+FROM (
+  SELECT
+    "normalized_name",
+    "normalized_comment",
+    SUM("usage_count") AS "usage_count",
+    MAX("last_used_at") AS "last_used_at",
+    MIN("created_at") AS "created_at",
+    MAX("updated_at") AS "updated_at"
+  FROM "item_suggestions"
+  GROUP BY "normalized_name", "normalized_comment"
+) AS totals
+JOIN (
+  SELECT DISTINCT ON ("normalized_name", "normalized_comment")
+    "normalized_name",
+    "normalized_comment",
+    "name",
+    "comment",
+    "icon_key"
+  FROM "item_suggestions"
+  ORDER BY "normalized_name", "normalized_comment", "last_used_at" DESC, "updated_at" DESC, "created_at" DESC
+) AS chosen
+  ON chosen."normalized_name" = totals."normalized_name"
+ AND chosen."normalized_comment" = totals."normalized_comment";
+
+DROP TABLE "item_suggestions";
+
+ALTER TABLE "item_suggestions_new" RENAME TO "item_suggestions";
+
+CREATE UNIQUE INDEX "item_suggestions_normalized_name_normalized_comment_key"
+ON "item_suggestions"("normalized_name", "normalized_comment");
+
+CREATE INDEX "item_suggestions_usage_count_last_used_at_idx"
+ON "item_suggestions"("usage_count", "last_used_at");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -17,7 +17,6 @@ model User {
   archivedLists     ShoppingList[]   @relation("archived_lists")
   memberships       ListMember[]
   createdItems      ListItem[]
-  itemSuggestions   ItemSuggestion[]
   authSessions      AuthSession[]
   claimedInvites    ListInvitation[] @relation("claimed_invitations")
   sentInvitations   ListInvitation[] @relation("sent_invitations")
@@ -127,7 +126,6 @@ model ListItem {
 
 model ItemSuggestion {
   id                String   @id @default(cuid())
-  userId            String   @map("user_id")
   name              String
   normalizedName    String   @map("normalized_name")
   comment           String?
@@ -137,10 +135,9 @@ model ItemSuggestion {
   lastUsedAt        DateTime @default(now()) @map("last_used_at")
   createdAt         DateTime @default(now()) @map("created_at")
   updatedAt         DateTime @updatedAt @map("updated_at")
-  user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@unique([userId, normalizedName, normalizedComment])
-  @@index([userId, usageCount, lastUsedAt])
+  @@unique([normalizedName, normalizedComment])
+  @@index([usageCount, lastUsedAt])
   @@map("item_suggestions")
 }
 

--- a/backend/src/modules/items/routes.test.ts
+++ b/backend/src/modules/items/routes.test.ts
@@ -51,7 +51,6 @@ type TestSession = {
 
 type TestSuggestion = {
   id: string;
-  userId: string;
   name: string;
   normalizedName: string;
   comment: string | null;
@@ -106,7 +105,6 @@ function buildItem(overrides: Partial<TestItem> = {}): TestItem {
 function buildSuggestion(overrides: Partial<TestSuggestion> = {}): TestSuggestion {
   return {
     id: 'suggestion_1',
-    userId: 'user_1',
     name: 'Milk',
     normalizedName: 'milk',
     comment: '2%',
@@ -181,15 +179,13 @@ async function buildApp(
     },
     itemSuggestion: {
       findMany: async ({
-        where,
         take
       }: {
-        where: { userId: string };
         orderBy: Array<{ usageCount?: 'asc' | 'desc' } | { lastUsedAt?: 'asc' | 'desc' } | { name?: 'asc' | 'desc' }>;
         take: number;
       }) => {
         const suggestions = [...suggestionsById.values()]
-          .filter((suggestion): suggestion is TestSuggestion => Boolean(suggestion && suggestion.userId === where.userId))
+          .filter((suggestion): suggestion is TestSuggestion => Boolean(suggestion))
           .sort((left, right) => {
             if (right.usageCount != left.usageCount) {
               return right.usageCount - left.usageCount;
@@ -207,14 +203,12 @@ async function buildApp(
       findFirst: async ({
         where
       }: {
-        where: { userId: string; normalizedName: string; normalizedComment: string };
+        where: { normalizedName: string; normalizedComment: string };
       }) => {
         return (
           [...suggestionsById.values()].find(
             (suggestion) =>
-              suggestion?.userId === where.userId &&
-              suggestion.normalizedName === where.normalizedName &&
-              suggestion.normalizedComment === where.normalizedComment
+              suggestion?.normalizedName === where.normalizedName && suggestion.normalizedComment === where.normalizedComment
           ) ?? null
         );
       },
@@ -222,7 +216,6 @@ async function buildApp(
         data
       }: {
         data: {
-          userId: string;
           name: string;
           normalizedName: string;
           comment?: string | null;
@@ -234,7 +227,6 @@ async function buildApp(
       }) => {
         const suggestion = buildSuggestion({
           id: `suggestion_${suggestionsById.size + 1}`,
-          userId: data.userId,
           name: data.name,
           normalizedName: data.normalizedName,
           comment: data.comment ?? null,
@@ -430,20 +422,19 @@ function buildSessionToken(userId: string) {
   return { rawToken, session };
 }
 
-test('GET /items/suggestions returns ranked suggestions for the user', async () => {
+test('GET /items/suggestions returns ranked shared suggestions', async () => {
   const user = buildUser();
   const suggestions = new Map<string, TestSuggestion | undefined>([
     [
       'suggestion_1',
       buildSuggestion({
         id: 'suggestion_1',
-        userId: user.id,
         name: 'Milk',
         iconKey: 'eggs',
         usageCount: 10
       })
     ],
-    ['suggestion_2', buildSuggestion({ id: 'suggestion_2', userId: user.id, name: 'Batteries', usageCount: 2 })]
+    ['suggestion_2', buildSuggestion({ id: 'suggestion_2', name: 'Batteries', usageCount: 2 })]
   ]);
   const { rawToken, session } = buildSessionToken(user.id);
   const app = await buildApp(new Map([[user.id, user]]), new Map(), new Map(), suggestions, [session]);
@@ -524,7 +515,7 @@ test('PATCH /lists/:listId/items/:itemId updates an item', async () => {
   const item = buildItem({ id: 'item_1', listId: list.id, name: 'Milk', quantity: 1, comment: '2%', isChecked: false, createdByUserId: user.id });
   const { rawToken, session } = buildSessionToken(user.id);
   const suggestions = new Map<string, TestSuggestion | undefined>([
-    ['suggestion_1', buildSuggestion({ id: 'suggestion_1', userId: user.id, name: 'Milk', comment: '2%', normalizedComment: '2%', usageCount: 4 })]
+    ['suggestion_1', buildSuggestion({ id: 'suggestion_1', name: 'Milk', comment: '2%', normalizedComment: '2%', usageCount: 4 })]
   ]);
   const app = await buildApp(
     new Map([[user.id, user]]),
@@ -582,6 +573,48 @@ test('PATCH /lists/:listId/items/:itemId updates an item icon', async () => {
 
     assert.equal(response.statusCode, 200);
     assert.equal(response.json().item.iconKey, 'bread');
+  } finally {
+    await app.close();
+  }
+});
+
+test('shared suggestions are visible across different users on the same backend', async () => {
+  const firstUser = buildUser({ id: 'user_1', email: 'first@example.com' });
+  const secondUser = buildUser({ id: 'user_2', email: 'second@example.com', displayName: 'Second User' });
+  const suggestions = new Map<string, TestSuggestion | undefined>([
+    [
+      'suggestion_1',
+      buildSuggestion({
+        id: 'suggestion_1',
+        name: 'Tomatoes',
+        iconKey: 'vegetables',
+        usageCount: 7
+      })
+    ]
+  ]);
+  const firstSession = buildSessionToken(firstUser.id);
+  const secondSession = buildSessionToken(secondUser.id);
+  const app = await buildApp(
+    new Map([
+      [firstUser.id, firstUser],
+      [secondUser.id, secondUser]
+    ]),
+    new Map(),
+    new Map(),
+    suggestions,
+    [firstSession.session, secondSession.session]
+  );
+
+  try {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/items/suggestions',
+      headers: { authorization: `Bearer ${secondSession.rawToken}` }
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.json().items.map((item: { name: string }) => item.name), ['Tomatoes']);
+    assert.equal(response.json().items[0].iconKey, 'vegetables');
   } finally {
     await app.close();
   }

--- a/backend/src/modules/items/routes.ts
+++ b/backend/src/modules/items/routes.ts
@@ -44,7 +44,6 @@ type ItemSuggestionResponse = {
 
 type ItemSuggestionRecord = {
   id: string;
-  userId: string;
   name: string;
   normalizedName: string;
   comment: string | null;
@@ -147,20 +146,17 @@ type ItemRoutesDeps = {
     listItem: ItemRepository;
     itemSuggestion: {
       findMany(args: {
-        where: { userId: string };
         orderBy: Array<{ usageCount?: 'asc' | 'desc' } | { lastUsedAt?: 'asc' | 'desc' } | { name?: 'asc' | 'desc' }>;
         take: number;
       }): Promise<ItemSuggestionRecord[]>;
       findFirst(args: {
         where: {
-          userId: string;
           normalizedName: string;
           normalizedComment: string;
         };
       }): Promise<ItemSuggestionRecord | null>;
       create(args: {
         data: {
-          userId: string;
           name: string;
           normalizedName: string;
           comment?: string | null;
@@ -317,7 +313,6 @@ function normalizeSuggestionPart(value: string | null | undefined) {
 
 async function recordSuggestionUsage(
   deps: ItemRoutesDeps,
-  userId: string,
   {
     name,
     comment,
@@ -340,7 +335,6 @@ async function recordSuggestionUsage(
   const now = new Date();
   const existingSuggestion = await deps.prisma.itemSuggestion.findFirst({
     where: {
-      userId,
       normalizedName,
       normalizedComment
     }
@@ -376,7 +370,6 @@ async function recordSuggestionUsage(
 
   await deps.prisma.itemSuggestion.create({
     data: {
-      userId,
       name: name.trim(),
       normalizedName,
       comment: comment?.trim() ?? null,
@@ -398,9 +391,6 @@ export function createItemRoutes(deps: ItemRoutesDeps = defaultDeps): FastifyPlu
       }
 
       const suggestions = await deps.prisma.itemSuggestion.findMany({
-        where: {
-          userId: user.id
-        },
         orderBy: [{ usageCount: 'desc' }, { lastUsedAt: 'desc' }, { name: 'asc' }],
         take: 12
       });
@@ -472,7 +462,7 @@ export function createItemRoutes(deps: ItemRoutesDeps = defaultDeps): FastifyPlu
         }
       });
 
-      await recordSuggestionUsage(deps, user.id, {
+      await recordSuggestionUsage(deps, {
         name: item.name,
         comment: item.comment,
         iconKey: item.iconKey,
@@ -531,7 +521,7 @@ export function createItemRoutes(deps: ItemRoutesDeps = defaultDeps): FastifyPlu
         }
       });
 
-      await recordSuggestionUsage(deps, user.id, {
+      await recordSuggestionUsage(deps, {
         name: nextName,
         comment: nextComment,
         iconKey: item.iconKey,

--- a/docs/api.md
+++ b/docs/api.md
@@ -502,6 +502,7 @@ Response:
 Notes:
 - suggestions are ranked by `usageCount`, then by most recent use
 - usage is updated when a user creates an item or increases its quantity
+- suggestions are shared across every app connected to the same backend
 - the last chosen icon is stored with each suggestion and reused the next time the same product is selected
 
 ### `DELETE /lists/:listId/items/:itemId`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -233,10 +233,10 @@ NestJS is also valid, but Fastify keeps the first version leaner.
 
 #### item_suggestions
 - `id`
-- `user_id`
 - `name`
 - `normalized_name`
 - `comment`
+- `icon_key`
 - `normalized_comment`
 - `usage_count`
 - `last_used_at`
@@ -251,6 +251,7 @@ NestJS is also valid, but Fastify keeps the first version leaner.
 - `role` can start with `owner` and `editor`.
 - `sort_order` makes manual ordering possible later.
 - `updated_at` is enough for the first synchronization approach.
+- `item_suggestions` is a backend-wide catalog shared by all connected apps, so learned product names and icon assignments stay consistent between users.
 
 ## Authentication model
 


### PR DESCRIPTION
## Summary
This changes item suggestions from user-scoped records to a backend-wide shared catalog so product suggestions and icon/category assignments are reused across every app connected to the same Listek backend.

## Why
Two users sharing the same backend were each training separate suggestion catalogs. That meant:
- one person's icon/category assignment for a product was not visible to the other person
- suggested products were not shared between the two apps

The root cause was that `item_suggestions` was keyed by `user_id`, and the API only read and updated suggestions for the current authenticated user.

## What changed
- removed `user_id` scoping from `item_suggestions`
- updated item suggestion reads and writes to use a shared backend catalog
- added a Prisma migration that merges existing per-user suggestions into shared records
- added coverage proving suggestions are visible across different users on the same backend
- updated API and architecture docs to reflect the shared behavior

## Impact
After deploying the migration, learned product names and icon assignments will stay consistent for all apps using the same backend.

## Validation
- `node --import tsx --test src/modules/items/routes.test.ts`
- `npm run build`